### PR TITLE
fix(api): trustmarks have expiry in hours

### DIFF
--- a/admin/tests/test_api.py
+++ b/admin/tests/test_api.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 
@@ -187,7 +188,7 @@ def test_trustmark_create(db, loadredis):
 
     self = TestCase()
     self.maxDiff = None
-    data = {"tmt": 2, "domain": domain}
+    data = {"tmt": 2, "domain": domain, "valid_for": 24}
     client: TestClient = TestClient(router)
     response = client.post("/trustmarks", json=data)
 
@@ -197,6 +198,11 @@ def test_trustmark_create(db, loadredis):
     payload = get_payload(jwt_token)
     self.assertEqual(domain, payload.get("sub"))
     self.assertEqual("https://example.com/trust_mark_type", payload.get("trust_mark_type"))
+    # The following is to test #51
+    iat = datetime.datetime.fromtimestamp(payload.get("iat"), datetime.timezone.utc)
+    exp = datetime.datetime.fromtimestamp(payload.get("exp"), datetime.timezone.utc)
+    diff = exp - iat
+    self.assertEqual(diff.days, 1)
 
 
 @pytest.mark.django_db

--- a/admin/trustmarks/lib.py
+++ b/admin/trustmarks/lib.py
@@ -32,8 +32,7 @@ def add_trustmark(entity: str, trustmarktype: str, expiry: int, r: redis.Redis) 
     sub_data = {"iss": settings.TRUSTMARK_PROVIDER}
     sub_data["sub"] = entity
     now = datetime.now()
-    # FIXME: timedelta should be in hours
-    exp = now + timedelta(days=expiry)
+    exp = now + timedelta(hours=expiry)
     sub_data["iat"] = now.timestamp()
     sub_data["exp"] = exp.timestamp()
     # TODO: ref: we have to add this claim too in future

--- a/changelog.d/20251125_143528_kushal_expiry_in_hours.md
+++ b/changelog.d/20251125_143528_kushal_expiry_in_hours.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- #51 Trustmarks now have hours in expiry.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->


### PR DESCRIPTION
Fixes #51 Now by default trustmarks are expiring in hours.