### PR TITLE
fix: bind address for TA

### DIFF
--- a/src/bin/inmor/main.rs
+++ b/src/bin/inmor/main.rs
@@ -197,6 +197,7 @@ async fn main() -> io::Result<()> {
             .run()
             .await
     } else {
-        http_server.run().await
+        eprintln!("Starting HTTP server on 0.0.0.0:{}", port);
+        http_server.bind(("0.0.0.0", port))?.run().await
     }
 }


### PR DESCRIPTION
Fixes #136 when we don't use TLS on TA, it should have proper bind address