### PR TITLE
fix: add Fetch Config button to Edit Subordinate modal

### DIFF
--- a/admin/frontend/vite.config.ts
+++ b/admin/frontend/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig(({ mode }) => {
     define: {
       // Make the API URL available at runtime
       // Use same origin for dev (proxy configured above), or explicit URL for production
-      __API_URL__: JSON.stringify(env.VITE_API_URL || (mode === 'development' ? '' : 'http://localhost:8000')),
+      __API_URL__: JSON.stringify(env.VITE_API_URL || ''),
     },
   }
 })

--- a/changelog.d/20260212_111015_kushal_refetch.md
+++ b/changelog.d/20260212_111015_kushal_refetch.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+### Added
+
+- Refetch metadata button to the frontend #164
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->


### PR DESCRIPTION
Fixes #164, the Edit Subordinate modal was missing the ability to re-fetch an entity's configuration. Added the same Fetch Config button from the Create modal, skipping the duplicate entity check since the subordinate already exists.