### PR TITLE
fix: don't include null metadata in policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "oidfed_metadata_policy"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40da4e41067d290fa7ec4b67335c979a7c48faaef4c53dfe05e119a4d2f0a2b"
+checksum = "04d654e0192cd6e14a2aa6e7f6a62e7a463f2862906d8b6e7e9ec5fbef5c08d9"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -2244,7 +2244,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tokio = { version = "1", features = ["full"] }
 env_logger = "0.11.8"
 log = "0.4.27"
 base64 = "0.22"
-oidfed_metadata_policy = "0.7.0"
+oidfed_metadata_policy = "0.8.0"
 anyhow = "1.0.98"
 toml = "0.9.0"
 clap = { version = "4.5.41", features = ["derive"] }

--- a/changelog.d/20260213_100720_kushal_metadata_null.md
+++ b/changelog.d/20260213_100720_kushal_metadata_null.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- don't include null metadata in policy document
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1266,7 +1266,10 @@ pub async fn resolve_entity(
                             "metadata is not an object",
                         );
                     };
-                    let full_policy = json!({"metadata_policy": val.clone(), "metadata": forced_metadata.clone()});
+                    let full_policy = match forced_metadata {
+                        Some(fm) => json!({"metadata_policy": val.clone(), "metadata": fm.clone()}),
+                        None => json!({"metadata_policy": val.clone()}),
+                    };
                     let Some(full_policy_document) = full_policy.as_object() else {
                         return error_response_400(
                             "invalid_trust_chain",


### PR DESCRIPTION
Fixes #167 hen no forced metadata exists in the trust chain (at the TA level), `forced_metadata` is `None` which `json!` serialized as `"metadata": null`. This caused `oidfed_metadata_policy` to panic with `unwrap()` on a `None` value when it tried to call `.as_object()` on the null.

Only include the `metadata` key in the policy document when forced metadata actually exists.