### PR TITLE
add: health and status endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ EOT
 
 RUN <<EOT
 apt-get clean
-apt update && apt install xmlsec1 redis ca-certificates -y
+apt update && apt install xmlsec1 redis ca-certificates curl -y
 apt dist-upgrade -y
 
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     networks:
       - inmor-net
     healthcheck:
-      test: ['CMD', 'true']
-      interval: 1s
+      test: ['CMD', 'curl', '--insecure', '--fail', '--silent', 'https://localhost:8080/health']
+      interval: 5s
       timeout: 5s
       retries: 5
       start_period: 10s

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -503,10 +503,55 @@ Health Checks
 
 All services have health checks configured:
 
-* **ta**: Basic connectivity check
+* **ta**: ``GET /health`` — verifies Redis connectivity, returns ``{"status": "ok"}`` (200) or ``{"status": "error", "detail": "redis unavailable"}`` (503)
 * **admin**: Django application health
 * **db**: PostgreSQL ready check (``pg_isready``)
 * **redis**: Redis ping
+
+The TA ``/health`` endpoint is used as the Docker healthcheck::
+
+   healthcheck:
+     test: ['CMD', 'curl', '--insecure', '--fail', '--silent', 'https://localhost:8080/health']
+     interval: 5s
+     timeout: 5s
+     retries: 5
+     start_period: 10s
+
+For detailed operational status (subordinate counts, trust mark types, collection stats),
+use the ``/status`` endpoint::
+
+   curl https://your-ta-domain/status
+
+Example response:
+
+.. code-block:: json
+
+   {
+     "entity_id": "https://federation.example.com",
+     "version": "0.3.0",
+     "status": "ok",
+     "keys": {
+       "public_keys": 3,
+       "historical_keys_available": true
+     },
+     "subordinates": {
+       "direct": 4
+     },
+     "trust_marks": {
+       "types": [
+         "https://example.com/trustmark/member",
+         "https://example.com/trustmark/certified"
+       ],
+       "total_issued": 89
+     },
+     "collection": {
+       "total_entities": 523,
+       "openid_providers": 150,
+       "openid_relying_parties": 300,
+       "intermediates": 10,
+       "last_updated": 1708420000
+     }
+   }
 
 Monitor health status::
 

--- a/src/bin/inmor/main.rs
+++ b/src/bin/inmor/main.rs
@@ -385,6 +385,8 @@ async fn main() -> io::Result<()> {
             .service(trust_mark_list)
             .service(trust_mark_status)
             .service(federation_historical_keys)
+            .service(health)
+            .service(server_status)
             .wrap(middleware::NormalizePath::trim())
             .wrap(middleware::Logger::default())
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1394,6 +1394,110 @@ pub async fn add_subordinate(entity_id: &str) -> Result<String> {
     Ok("all good".to_string())
 }
 
+/// Lightweight liveness check endpoint.
+/// Returns 200 with `{"status": "ok"}` if Redis is reachable,
+/// or 503 with `{"status": "error", "detail": "redis unavailable"}` if not.
+#[get("/health")]
+pub async fn health(redis: web::Data<redis::Client>) -> HttpResponse {
+    let conn_result = redis.get_connection_manager().await;
+    match conn_result {
+        Ok(mut conn) => {
+            let ping: Result<String, _> = redis::cmd("PING").query_async(&mut conn).await;
+            match ping {
+                Ok(_) => HttpResponse::Ok().json(json!({"status": "ok"})),
+                Err(_) => HttpResponse::ServiceUnavailable()
+                    .json(json!({"status": "error", "detail": "redis unavailable"})),
+            }
+        }
+        Err(_) => HttpResponse::ServiceUnavailable()
+            .json(json!({"status": "error", "detail": "redis unavailable"})),
+    }
+}
+
+/// Detailed operational status endpoint.
+/// Returns counts of keys, subordinates, trust marks, and collection data.
+#[get("/status")]
+pub async fn server_status(
+    redis: web::Data<redis::Client>,
+    state: web::Data<AppState>,
+) -> actix_web::Result<HttpResponse> {
+    let mut conn = redis
+        .get_connection_manager()
+        .await
+        .map_err(error::ErrorInternalServerError)?;
+
+    // Pipeline Redis queries for efficiency (single round-trip)
+    let mut pipe = redis::pipe();
+    pipe.cmd("EXISTS")
+        .arg("inmor:historical_keys")
+        .cmd("HLEN")
+        .arg("inmor:subordinates:jwt")
+        .cmd("SCARD")
+        .arg("inmor:tm:alltime")
+        .cmd("HLEN")
+        .arg("inmor:collection:entities")
+        .cmd("SCARD")
+        .arg("inmor:collection:by_type:openid_provider")
+        .cmd("SCARD")
+        .arg("inmor:collection:by_type:openid_relying_party")
+        .cmd("SCARD")
+        .arg("inmor:collection:by_type:federation_entity")
+        .cmd("GET")
+        .arg("inmor:collection:last_updated")
+        .cmd("KEYS")
+        .arg("inmor:tmtype:*");
+
+    let results: (
+        bool,        // historical_keys exists
+        u64,         // subordinate count
+        u64,         // total trust marks
+        u64,         // collection entities
+        u64,         // OPs
+        u64,         // RPs
+        u64,         // intermediates
+        Option<u64>, // last_updated
+        Vec<String>, // trust mark type keys
+    ) = pipe
+        .query_async(&mut conn)
+        .await
+        .map_err(error::ErrorInternalServerError)?;
+
+    // Extract trust mark type URLs from Redis key names
+    let trust_mark_types: Vec<String> = results
+        .8
+        .iter()
+        .filter_map(|key| key.strip_prefix("inmor:tmtype:").map(String::from))
+        .collect();
+
+    let public_key_count = PUBLIC_KEYS.len();
+
+    let response = json!({
+        "entity_id": state.entity_id,
+        "version": env!("CARGO_PKG_VERSION"),
+        "status": "ok",
+        "keys": {
+            "public_keys": public_key_count,
+            "historical_keys_available": results.0,
+        },
+        "subordinates": {
+            "direct": results.1,
+        },
+        "trust_marks": {
+            "types": trust_mark_types,
+            "total_issued": results.2,
+        },
+        "collection": {
+            "total_entities": results.3,
+            "openid_providers": results.4,
+            "openid_relying_parties": results.5,
+            "intermediates": results.6,
+            "last_updated": results.7,
+        },
+    });
+
+    Ok(HttpResponse::Ok().json(response))
+}
+
 pub fn error_response_404(edetails: &str, message: &str) -> actix_web::Result<HttpResponse> {
     Ok(HttpResponse::NotFound()
         .content_type("application/json")

--- a/tests/test_inmor.py
+++ b/tests/test_inmor.py
@@ -522,3 +522,56 @@ def test_historical_keys_revoked_field(loaddata: Redis, start_server: int, http_
             assert revoked.get("reason") in ["unspecified", "compromised", "superseded"], (
                 f"revoked reason should be one of: unspecified, compromised, superseded"
             )
+
+
+def test_health_endpoint(loaddata: Redis, start_server: int, http_client: Client):
+    "Tests /health endpoint returns ok when Redis is reachable"
+    _rdb = loaddata
+    port = start_server
+    url = f"https://localhost:{port}/health"
+    resp = http_client.get(url)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("status") == "ok"
+
+
+def test_status_endpoint(loaddata: Redis, start_server: int, http_client: Client):
+    "Tests /status endpoint returns detailed operational status"
+    _rdb = loaddata
+    port = start_server
+    url = f"https://localhost:{port}/status"
+    resp = http_client.get(url)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Verify top-level fields
+    assert data.get("entity_id") == f"https://localhost:{port}"
+    assert data.get("version") is not None
+    assert data.get("status") == "ok"
+
+    # Verify keys section
+    keys = data.get("keys")
+    assert keys is not None, "keys section missing"
+    assert isinstance(keys.get("public_keys"), int)
+    assert keys["public_keys"] > 0
+    assert isinstance(keys.get("historical_keys_available"), bool)
+
+    # Verify subordinates section
+    subordinates = data.get("subordinates")
+    assert subordinates is not None, "subordinates section missing"
+    assert isinstance(subordinates.get("direct"), int)
+    assert subordinates["direct"] == 3  # test data has 3 subordinates
+
+    # Verify trust_marks section
+    trust_marks = data.get("trust_marks")
+    assert trust_marks is not None, "trust_marks section missing"
+    assert isinstance(trust_marks.get("types"), list)
+    assert isinstance(trust_marks.get("total_issued"), int)
+
+    # Verify collection section
+    collection = data.get("collection")
+    assert collection is not None, "collection section missing"
+    assert isinstance(collection.get("total_entities"), int)
+    assert isinstance(collection.get("openid_providers"), int)
+    assert isinstance(collection.get("openid_relying_parties"), int)
+    assert isinstance(collection.get("intermediates"), int)


### PR DESCRIPTION
Fixes #176, replaces the no-op Docker healthcheck with a real /health endpoint that verifies Redis connectivity. Add /status for detailed operational stats (keys, subordinates, trust marks, collection counts) using a pipelined Redis query.