### PR TITLE
add: apikey management command

### DIFF
--- a/admin/apikeys/management/commands/apikey.py
+++ b/admin/apikeys/management/commands/apikey.py
@@ -1,0 +1,142 @@
+"""Management command for API key management.
+
+Usage:
+    python manage.py apikey create --username admin --key-name "CI deploy"
+    python manage.py apikey list --username admin
+    python manage.py apikey list --all
+    python manage.py apikey revoke --username admin --key-name "CI deploy"
+"""
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from apikeys.models import APIKey
+
+
+class Command(BaseCommand):
+    help = "Manage API keys: create, list, or revoke."
+
+    def add_arguments(self, parser):
+        subparsers = parser.add_subparsers(dest="subcommand")
+        subparsers.required = True
+
+        # create
+        create_parser = subparsers.add_parser("create", help="Create a new API key")
+        create_parser.add_argument(
+            "--username", type=str, required=True, help="Username of the key owner"
+        )
+        create_parser.add_argument(
+            "--key-name",
+            type=str,
+            default="auto-generated",
+            help="Descriptive name for the API key",
+        )
+
+        # list
+        list_parser = subparsers.add_parser("list", help="List API keys")
+        list_group = list_parser.add_mutually_exclusive_group(required=True)
+        list_group.add_argument("--username", type=str, help="Username to list keys for")
+        list_group.add_argument(
+            "--all", action="store_true", dest="all_users", help="List keys for all users"
+        )
+
+        # revoke
+        revoke_parser = subparsers.add_parser("revoke", help="Revoke an API key")
+        revoke_parser.add_argument(
+            "--username", type=str, required=True, help="Username of the key owner"
+        )
+        revoke_parser.add_argument(
+            "--key-name", type=str, required=True, help="Name of the key to revoke"
+        )
+
+    def handle(self, *args, **options):
+        subcommand = options["subcommand"]
+        if subcommand == "create":
+            self.handle_create(options)
+        elif subcommand == "list":
+            self.handle_list(options)
+        elif subcommand == "revoke":
+            self.handle_revoke(options)
+
+    def handle_create(self, options):
+        User = get_user_model()
+        username = options["username"]
+        key_name = options["key_name"]
+
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            raise CommandError(f"User '{username}' does not exist")
+
+        _, plaintext_key = APIKey.create_key(name=key_name, user=user)
+
+        # Print only the key so it can be captured by scripts
+        self.stdout.write(plaintext_key)
+
+    def handle_list(self, options):
+        User = get_user_model()
+        show_all = options.get("all_users", False)
+
+        if show_all:
+            keys = APIKey.objects.select_related("user").all()
+        else:
+            username = options["username"]
+            try:
+                user = User.objects.get(username=username)
+            except User.DoesNotExist:
+                raise CommandError(f"User '{username}' does not exist")
+            keys = APIKey.objects.filter(user=user)
+
+        if not keys.exists():
+            self.stdout.write("No API keys found.")
+            return
+
+        # Header
+        if show_all:
+            self.stdout.write(
+                f"{'Name':<25} {'Prefix':<10} {'User':<15} {'Active':<8} "
+                f"{'Created':<20} {'Expires':<20} {'Last Used':<20}"
+            )
+            self.stdout.write("-" * 118)
+        else:
+            self.stdout.write(
+                f"{'Name':<25} {'Prefix':<10} {'Active':<8} "
+                f"{'Created':<20} {'Expires':<20} {'Last Used':<20}"
+            )
+            self.stdout.write("-" * 103)
+
+        for key in keys:
+            created = key.created_at.strftime("%Y-%m-%d %H:%M") if key.created_at else "-"
+            expires = key.expires_at.strftime("%Y-%m-%d %H:%M") if key.expires_at else "never"
+            last_used = key.last_used_at.strftime("%Y-%m-%d %H:%M") if key.last_used_at else "never"
+            active = "yes" if key.is_active else "no"
+
+            if show_all:
+                self.stdout.write(
+                    f"{key.name:<25} {key.prefix:<10} {key.user.username:<15} "
+                    f"{active:<8} {created:<20} {expires:<20} {last_used:<20}"
+                )
+            else:
+                self.stdout.write(
+                    f"{key.name:<25} {key.prefix:<10} {active:<8} "
+                    f"{created:<20} {expires:<20} {last_used:<20}"
+                )
+
+    def handle_revoke(self, options):
+        User = get_user_model()
+        username = options["username"]
+        key_name = options["key_name"]
+
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            raise CommandError(f"User '{username}' does not exist")
+
+        keys = APIKey.objects.filter(user=user, name=key_name, is_active=True)
+        count = keys.count()
+
+        if count == 0:
+            raise CommandError(f"No active API key named '{key_name}' found for user '{username}'")
+
+        keys.update(is_active=False)
+        self.stdout.write(f"Revoked {count} key(s) named '{key_name}' for user '{username}'.")

--- a/admin/tests/test_apikeys.py
+++ b/admin/tests/test_apikeys.py
@@ -203,3 +203,123 @@ class TestAPIKeyAuthentication:
         """Test that session authentication still works."""
         response = auth_client.get("/api/v1/trustmarktypes")
         assert response.status_code == 200
+
+
+class TestAPIKeyManagementCommand:
+    """Tests for the apikey management command."""
+
+    @pytest.mark.django_db
+    def test_apikey_create(self, user):
+        """Test creating an API key via management command."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command(
+            "apikey", "create", "--username", "testuser", "--key-name", "test key", stdout=out
+        )
+        plaintext = out.getvalue().strip()
+
+        assert len(plaintext) > 20
+        key = APIKey.objects.get(name="test key", user=user)
+        assert key.is_active is True
+        assert plaintext.startswith(key.prefix)
+
+    @pytest.mark.django_db
+    def test_apikey_create_user_not_found(self, db):
+        """Test creating an API key for a non-existent user."""
+        from io import StringIO
+
+        from django.core.management import call_command, CommandError
+
+        with pytest.raises(CommandError, match="does not exist"):
+            call_command("apikey", "create", "--username", "nobody", stdout=StringIO())
+
+    @pytest.mark.django_db
+    def test_apikey_list(self, user):
+        """Test listing API keys for a user."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        APIKey.create_key(name="key-one", user=user)
+        APIKey.create_key(name="key-two", user=user)
+
+        out = StringIO()
+        call_command("apikey", "list", "--username", "testuser", stdout=out)
+        output = out.getvalue()
+
+        assert "key-one" in output
+        assert "key-two" in output
+
+    @pytest.mark.django_db
+    def test_apikey_list_all(self, user):
+        """Test listing all API keys across users."""
+        from io import StringIO
+
+        from django.contrib.auth.models import User
+        from django.core.management import call_command
+
+        user2 = User.objects.create_user(username="otheruser", password="pass123")
+        APIKey.create_key(name="key-for-test", user=user)
+        APIKey.create_key(name="key-for-other", user=user2)
+
+        out = StringIO()
+        call_command("apikey", "list", "--all", stdout=out)
+        output = out.getvalue()
+
+        assert "key-for-test" in output
+        assert "key-for-other" in output
+        assert "testuser" in output
+        assert "otheruser" in output
+
+    @pytest.mark.django_db
+    def test_apikey_list_empty(self, user):
+        """Test listing keys when user has none."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("apikey", "list", "--username", "testuser", stdout=out)
+        output = out.getvalue()
+
+        assert "No API keys found" in output
+
+    @pytest.mark.django_db
+    def test_apikey_revoke(self, user):
+        """Test revoking an API key by name."""
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        APIKey.create_key(name="revoke-me", user=user)
+
+        out = StringIO()
+        call_command(
+            "apikey", "revoke", "--username", "testuser", "--key-name", "revoke-me", stdout=out
+        )
+        output = out.getvalue()
+
+        assert "Revoked 1 key(s)" in output
+        key = APIKey.objects.get(name="revoke-me", user=user)
+        assert key.is_active is False
+
+    @pytest.mark.django_db
+    def test_apikey_revoke_not_found(self, user):
+        """Test revoking a non-existent key."""
+        from io import StringIO
+
+        from django.core.management import call_command, CommandError
+
+        with pytest.raises(CommandError, match="No active API key"):
+            call_command(
+                "apikey",
+                "revoke",
+                "--username",
+                "testuser",
+                "--key-name",
+                "nope",
+                stdout=StringIO(),
+            )

--- a/docs/guides/api-keys.rst
+++ b/docs/guides/api-keys.rst
@@ -26,8 +26,57 @@ Each API key is:
 * Optionally time-limited with an expiry date
 * Revocable at any time
 
-Creating an API Key
--------------------
+Command-Line Management
+-----------------------
+
+The ``apikey`` management command lets you create, list, and revoke API keys
+from the command line.
+
+Creating a Key
+^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   python manage.py apikey create --username admin --key-name "CI deploy"
+
+The plaintext key is printed to stdout so it can be captured by scripts.
+The ``--key-name`` flag is optional and defaults to ``auto-generated``.
+
+.. warning::
+
+   The plaintext API key is displayed **only once** at creation. If you
+   lose it, you must create a new key.
+
+Listing Keys
+^^^^^^^^^^^^
+
+List keys for a specific user:
+
+.. code-block:: bash
+
+   python manage.py apikey list --username admin
+
+List keys across all users:
+
+.. code-block:: bash
+
+   python manage.py apikey list --all
+
+Output includes the key name, prefix, active status, creation date, expiry,
+and last-used timestamp. The ``--all`` flag adds a user column.
+
+Revoking a Key
+^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   python manage.py apikey revoke --username admin --key-name "CI deploy"
+
+This deactivates all active keys matching the given name for that user.
+Revoked keys cannot be reactivated — create a new key instead.
+
+Creating a Key via Admin UI
+---------------------------
 
 Only Django superusers can create API keys through the admin interface.
 
@@ -42,11 +91,6 @@ Only Django superusers can create API keys through the admin interface.
 
 5. Click **Save**
 6. **Copy the displayed key immediately** -- it will not be shown again
-
-.. warning::
-
-   The plaintext API key is displayed **only once** after creation. If you
-   lose it, you must create a new key.
 
 Using an API Key
 ----------------
@@ -89,8 +133,8 @@ Examples
         -H "X-API-Key: YOUR_KEY_HERE" \
         https://your-server/api/v1/server/entity
 
-Managing API Keys
------------------
+Managing Keys via Admin UI
+--------------------------
 
 Viewing Keys
 ^^^^^^^^^^^^
@@ -115,8 +159,6 @@ To revoke multiple keys at once:
 1. Select the keys using the checkboxes
 2. Choose **Revoke selected API keys** from the action dropdown
 3. Click **Go**
-
-Revoked keys cannot be reactivated -- create a new key instead.
 
 Security Best Practices
 -----------------------

--- a/justfile
+++ b/justfile
@@ -111,7 +111,7 @@ recreate-data: recreate-fedora up
   echo "Sleeping for 5 seconds"
   sleep 5
   docker compose exec -T -e DJANGO_SUPERUSER_PASSWORD=testpass admin python manage.py setup_admin --username admin --noinput --skip-checks
-  INMOR_API_KEY=$(docker compose exec -T admin python manage.py create_api_key --username admin --skip-checks) python scripts/create_redis_db_data.py
+  INMOR_API_KEY=$(docker compose exec -T admin python manage.py apikey create --username admin --skip-checks) python scripts/create_redis_db_data.py
 
 # To regenerate the TA entity configuration
 regenerate-entity:


### PR DESCRIPTION
Fixes #178, subcommands:

- apikey create --username USER [--key-name NAME]
- apikey list --username USER | --all
- apikey revoke --username USER --key-name NAME

- Delete old create_api_key management command
- Update justfile recreate-data recipe to use new command
- Restructure docs/guides/api-keys.rst with CLI management as first section after Overview
- Add 7 tests covering all subcommands including error cases