### PR TITLE
add info about required step `just build-rs`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ The fastest way to get Inmor running is with Docker Compose::
 
    # Build and start all services
    just build
+   just build-rs
    just up
 
    # Initialize the Trust Anchor

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,11 +43,15 @@ Quick Installation
 
       just build
 
-3. Start all services::
+3. Build binaries::
+
+      just build-rs
+
+4. Start all services::
 
       just up
 
-4. Initialize the Trust Anchor::
+5. Initialize the Trust Anchor::
 
       # Create the entity configuration
       curl -X POST http://localhost:8000/api/v1/server/entity


### PR DESCRIPTION
Currently, the dev compose won't start if you don't have the file `./target/debug/inmor` on your host. This PR removes that.
Or perhaps it is intended that you run `just build-rs` before you start things up? If so, just close this PR.