### PR TITLE
feat: supports jwks_uri

### DIFF
--- a/admin/entities/lib.py
+++ b/admin/entities/lib.py
@@ -185,17 +185,34 @@ def update_redis_with_subordinate(
     _ = r.lpush("inmor:newsubordinate", entity_id)
 
 
+def fetch_jwks_from_uri(uri: str) -> JWKSet:
+    """Fetch a JWKS from a remote jwks_uri endpoint."""
+    resp = httpx.get(uri, timeout=10)
+    resp.raise_for_status()
+    return JWKSet.from_json(resp.text)
+
+
 def self_validate(token: jwt.JWT) -> dict[str, Any]:
-    """Self validates a JWT with JWKS from it."""
+    """Self validates a JWT with JWKS from it.
+
+    Tries inline jwks first, falls back to jwks_uri if available.
+    """
     try:
         payload = json.loads(token.token.objects.get("payload").decode("utf-8"))
-        # First get the jwks for self-verification
-        jwks_set = JWKSet()
-        keys = payload.get("jwks").get("keys")
-        for key in keys:
-            k = JWK(**key)
-            jwks_set.add(k)
-        token.validate(jwks_set)
+        jwks_data = payload.get("jwks")
+        if jwks_data is not None:
+            # Inline JWKS — standard path
+            jwks_set = JWKSet()
+            for key in jwks_data.get("keys", []):
+                jwks_set.add(JWK(**key))
+            token.validate(jwks_set)
+        elif payload.get("jwks_uri"):
+            # Fallback: fetch keys from jwks_uri
+            logger.info("No inline jwks, fetching from jwks_uri: %s", payload["jwks_uri"])
+            jwks_set = fetch_jwks_from_uri(payload["jwks_uri"])
+            token.validate(jwks_set)
+        else:
+            raise ValueError("No jwks or jwks_uri found in payload")
         return payload
     except Exception as e:
         raise Exception(str(e))

--- a/admin/inmoradmin/api.py
+++ b/admin/inmoradmin/api.py
@@ -19,6 +19,7 @@ from entities.lib import (
     create_server_statement,
     create_subordinate_statement,
     fetch_entity_configuration,
+    fetch_jwks_from_uri,
     fetch_payload,
     merge_our_policy_ontop_subpolicy,
     update_redis_with_subordinate,
@@ -825,7 +826,12 @@ class FetchConfigOutSchema(Schema):
     metadata: Annotated[
         dict[str, Any], Field(description="Entity metadata from the configuration.")
     ]
-    jwks: Annotated[dict[str, Any], Field(description="JWKS from the entity configuration.")]
+    jwks: Annotated[
+        dict[str, Any] | None, Field(description="JWKS from the entity configuration.")
+    ] = None
+    jwks_uri: Annotated[
+        str | None, Field(description="JWKS URI if entity uses remote keys instead of inline.")
+    ] = None
     authority_hints: Annotated[
         list[str] | None, Field(description="Authority hints from the configuration.")
     ] = None
@@ -848,9 +854,18 @@ def fetch_entity_config(request: HttpRequest, data: FetchConfigSchema):
     """
     try:
         payload, _jwt_str = fetch_payload(data.url)
+        jwks = payload.get("jwks")
+        # If no inline jwks, resolve from jwks_uri so the frontend always gets keys
+        if jwks is None and payload.get("jwks_uri"):
+            try:
+                resolved = fetch_jwks_from_uri(payload["jwks_uri"])
+                jwks = resolved.export(private_keys=False, as_dict=True)
+            except Exception:
+                pass  # Return None; frontend will show empty keys
         return 200, {
             "metadata": payload.get("metadata", {}),
-            "jwks": payload.get("jwks", {}),
+            "jwks": jwks,
+            "jwks_uri": payload.get("jwks_uri"),
             "authority_hints": payload.get("authority_hints"),
             "trust_marks": payload.get("trust_marks"),
         }

--- a/admin/tests/test_api.py
+++ b/admin/tests/test_api.py
@@ -954,3 +954,93 @@ def test_unauthenticated_server_entity(db):
     client = Client()
     response = client.post("/api/v1/server/entity")
     assert response.status_code == 401
+
+
+def test_self_validate_with_inline_jwks():
+    """self_validate works with inline JWKS (standard path)."""
+    from jwcrypto.jwk import JWK, JWKSet
+    from jwcrypto.jwt import JWT
+
+    key = JWK.generate(kty="EC", crv="P-256", kid="test-key-1")
+    keyset = JWKSet()
+    keyset.add(key)
+
+    claims = {
+        "iss": "https://example.com",
+        "sub": "https://example.com",
+        "jwks": keyset.export(private_keys=False, as_dict=True),
+    }
+
+    token = JWT(
+        header={"alg": "ES256", "kid": "test-key-1"},
+        claims=json.dumps(claims),
+    )
+    token.make_signed_token(key)
+    serialized = token.serialize()
+
+    parsed = jwt.JWT.from_jose_token(serialized)
+    payload = self_validate(parsed)
+    assert payload["iss"] == "https://example.com"
+    assert payload["sub"] == "https://example.com"
+    assert "jwks" in payload
+
+
+def test_self_validate_no_jwks_or_uri():
+    """self_validate raises when no jwks, jwks_uri, or signed_jwks_uri."""
+    from jwcrypto.jwk import JWK
+    from jwcrypto.jwt import JWT
+
+    key = JWK.generate(kty="EC", crv="P-256", kid="test-key-2")
+    claims = {
+        "iss": "https://example.com",
+        "sub": "https://example.com",
+        # No jwks, no jwks_uri
+    }
+
+    token = JWT(
+        header={"alg": "ES256", "kid": "test-key-2"},
+        claims=json.dumps(claims),
+    )
+    token.make_signed_token(key)
+    serialized = token.serialize()
+
+    parsed = jwt.JWT.from_jose_token(serialized)
+    with pytest.raises(Exception, match="No jwks or jwks_uri"):
+        self_validate(parsed)
+
+
+def test_self_validate_with_jwks_uri(monkeypatch):
+    """self_validate falls back to jwks_uri when inline jwks is missing."""
+    from jwcrypto.jwk import JWK, JWKSet
+    from jwcrypto.jwt import JWT
+
+    key = JWK.generate(kty="EC", crv="P-256", kid="test-key-3")
+    keyset = JWKSet()
+    keyset.add(key)
+
+    jwks_url = "https://example.com/.well-known/jwks.json"
+
+    # Mock fetch_jwks_from_uri to return our keyset
+    monkeypatch.setattr(
+        "entities.lib.fetch_jwks_from_uri",
+        lambda uri: keyset,
+    )
+
+    claims = {
+        "iss": "https://example.com",
+        "sub": "https://example.com",
+        "jwks_uri": jwks_url,
+        # No inline jwks
+    }
+
+    token = JWT(
+        header={"alg": "ES256", "kid": "test-key-3"},
+        claims=json.dumps(claims),
+    )
+    token.make_signed_token(key)
+    serialized = token.serialize()
+
+    parsed = jwt.JWT.from_jose_token(serialized)
+    payload = self_validate(parsed)
+    assert payload["iss"] == "https://example.com"
+    assert payload["jwks_uri"] == jwks_url

--- a/changelog.d/20260407_142947_kushal_jwks_uri.md
+++ b/changelog.d/20260407_142947_kushal_jwks_uri.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+### Added
+
+- `jwks_uri` support #212
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/docs/adr/0006-jwks-uri-support.md
+++ b/docs/adr/0006-jwks-uri-support.md
@@ -1,0 +1,68 @@
+# ADR 0006: Support `jwks_uri` for Remote Federation Key Retrieval
+
+## Status
+
+Accepted
+
+## Context
+
+The system previously required inline `jwks` claims in all entity configurations. Every function that needed an entity's public keys — self-verification, trust chain resolution (`/resolve`), and federation tree walking (`inmor-collection`) — extracted keys from `payload.claim("jwks")` and failed if the claim was absent.
+
+In practice, many federation entities publish their keys via `jwks_uri` (a URL pointing to a JWKS document) instead of embedding keys inline. The OpenID Federation 1.0 specification also defines `signed_jwks_uri` for a cryptographically signed variant. Without support for these, the Trust Anchor could not:
+
+- Resolve trust chains through intermediates that use `jwks_uri`
+- Walk federation trees containing entities without inline keys
+- Register subordinates whose entity configurations omit inline `jwks`
+
+On the Python side, `self_validate()` crashed with an `AttributeError` when `jwks` was `None`, since it called `.get("keys")` on `None`.
+
+### Spec Clarification
+
+Per OpenID Federation 1.0 Section 5.2.1, `jwks_uri` and `signed_jwks_uri` are metadata-level parameters (inside `metadata.openid_provider.*` etc.), not top-level entity statement claims. The top-level `jwks` is REQUIRED for entity statements. `signed_jwks_uri` is specifically for protocol keys (OP/RP) and requires signature verification using federation entity keys — it does not apply to federation key retrieval. Our implementation therefore only falls back to `jwks_uri` as a defensive measure for non-compliant entities, while the inline `jwks` path remains the primary and spec-compliant path.
+
+## Decision
+
+We add a two-level fallback chain: **inline `jwks` → `jwks_uri`**.
+
+### Rust (`src/lib.rs`)
+
+- **`fetch_jwks_from_uri(uri)`** — fetches a JWKS document from a remote URI using the existing shared HTTP client, with the same URL validation (SSRF protection, HTTPS enforcement) and response size limits as other federation requests.
+
+- **`parse_jwks_json(json_str)`** — shared helper to parse a JWKS JSON string into a `JwkSet`.
+
+- **`get_jwks_from_uri_cached(uri, redis_conn)`** — wraps `fetch_jwks_from_uri` with Redis-backed caching. Cache key: `inmor:jwks_cache:{sha256(uri)}`, TTL: 1 hour. Avoids repeated network round-trips during chain resolution.
+
+- **`get_jwks_from_payload_or_uri(payload, redis_conn)`** — the main entry point. Tries `get_jwks_from_payload()` first (inline keys), falls back to `jwks_uri` via `get_jwks_from_uri_cached()`.
+
+- **`resolve_entity_to_trustanchor()`** — updated to accept a `redis::aio::ConnectionManager` parameter and use `get_jwks_from_payload_or_uri()` instead of `get_jwks_from_payload()` when obtaining authority keys for subordinate statement verification.
+
+### Rust (`src/tree.rs`)
+
+- **`collection_tree_walking()`** and **`fetch_all_subordinate_statements()`** — when `self_verify_jwt()` fails, the code now extracts the unverified payload, attempts `get_jwks_from_payload_or_uri()` to fetch keys, and retries verification with the fetched keyset.
+
+### Python (`admin/entities/lib.py`)
+
+- **`fetch_jwks_from_uri(uri)`** — fetches a JWKS document via `httpx`.
+
+- **`self_validate()`** — fixed the `AttributeError` crash. Now checks for inline `jwks` first, falls back to `jwks_uri` (via `fetch_jwks_from_uri`). Raises a clear `ValueError` if neither is present.
+
+### Python (`admin/inmoradmin/api.py`)
+
+- **`FetchConfigOutSchema`** — added optional `jwks_uri` field so the fetch-config endpoint returns it when present. The endpoint also resolves `jwks_uri` into inline keys server-side so the frontend always receives populated `jwks`.
+
+### Why not `signed_jwks_uri`?
+
+Per OpenID Federation 1.0 Section 5.2.1, `signed_jwks_uri` is a metadata-level parameter for protocol keys (e.g., OP/RP keys under `metadata.openid_provider`). It requires signature verification using the entity's Federation Entity Keys. Since this implementation deals exclusively with federation key retrieval (top-level `jwks`), `signed_jwks_uri` does not apply — the top-level `jwks` is REQUIRED per spec, and `jwks_uri` is the only meaningful fallback for federation keys.
+
+### Caching Strategy
+
+JWKS responses are cached in Redis rather than in-process memory because the Rust server runs behind actix-web with multiple worker threads sharing the same Redis connection. A 1-hour TTL balances freshness (key rotation is infrequent in federation) against avoiding per-request latency. The Python side does not cache JWKS responses yet; this can be added via Django's cache framework if needed.
+
+## Consequences
+
+- Trust chain resolution now works through entities that publish `jwks_uri` instead of inline `jwks`
+- Federation tree walking discovers entities that were previously skipped due to missing inline keys
+- The `self_validate()` crash on missing `jwks` is fixed with a clear error path
+- JWKS fetches reuse the existing SSRF-protected HTTP client — no new attack surface
+- Redis stores cached JWKS with automatic expiry, avoiding stale keys and unbounded growth
+- The fallback chain is consistent across Rust and Python: `jwks` → `jwks_uri`

--- a/docs/api/admin.rst
+++ b/docs/api/admin.rst
@@ -786,6 +786,11 @@ Fetches and self-validates an entity's OpenID Federation configuration from
 their ``/.well-known/openid-federation`` endpoint. Use this before adding a
 subordinate to inspect their metadata and keys.
 
+If the entity publishes a ``jwks_uri`` instead of inline ``jwks``, the
+endpoint automatically fetches the keys from the URI and returns them as
+inline ``jwks`` in the response. This ensures the response always contains
+populated keys regardless of how the entity publishes them.
+
 **Request Body:**
 
 .. code-block:: json
@@ -822,6 +827,7 @@ subordinate to inspect their metadata and keys.
      "jwks": {
        "keys": [{"kty": "EC", "crv": "P-256", "x": "...", "y": "..."}]
      },
+     "jwks_uri": null,
      "authority_hints": ["https://federation.example.com"],
      "trust_marks": [
        {
@@ -830,6 +836,10 @@ subordinate to inspect their metadata and keys.
        }
      ]
    }
+
+The ``jwks_uri`` field is included in the response when the entity's
+configuration contains one. Even when ``jwks_uri`` is present, the ``jwks``
+field will be populated with the resolved keys.
 
 **Response (400 Bad Request):** Connection errors, invalid URL, signature
 validation failure, or no OpenID Federation configuration found.

--- a/docs/guides/subordinates.rst
+++ b/docs/guides/subordinates.rst
@@ -140,7 +140,9 @@ During registration, the API performs these validations:
 1. **Fetch Entity Configuration**: Downloads and parses the entity's
    ``/.well-known/openid-federation`` JWT
 
-2. **Verify Signature**: Validates the JWT signature using the provided JWKS
+2. **Verify Signature**: Validates the JWT signature using the provided JWKS.
+   If the entity's configuration uses ``jwks_uri`` instead of inline
+   ``jwks``, the keys are fetched from the URI automatically
 
 3. **Check Authority Hints**: Confirms your TA domain is in the entity's
    ``authority_hints`` list
@@ -388,6 +390,12 @@ The ``/resolve`` endpoint builds complete trust chains:
 * Final resolved metadata (after policy application)
 * Complete trust chain (array of JWTs)
 
+The resolve endpoint supports entities that publish ``jwks_uri`` instead of
+inline ``jwks`` in their entity configurations. When an authority in the
+chain lacks inline keys, the resolver fetches them from the ``jwks_uri``
+automatically. Fetched JWKS responses are cached in Redis for 1 hour to
+avoid repeated network round-trips during chain resolution.
+
 Entity Types
 ------------
 
@@ -592,8 +600,14 @@ Complete workflow for onboarding a new subordinate:
         -H "Content-Type: application/json" \
         -d '{"url": "https://new-entity.example.com"}'
 
-   This returns the entity's ``metadata``, ``jwks``, ``authority_hints``,
-   and ``trust_marks`` after signature validation.
+   This returns the entity's ``metadata``, ``jwks``, ``jwks_uri``,
+   ``authority_hints``, and ``trust_marks`` after signature validation.
+
+   If the entity publishes a ``jwks_uri`` instead of inline ``jwks``, the
+   endpoint automatically fetches the keys from the URI and returns them
+   as inline ``jwks`` in the response. This means the registration step
+   always receives populated keys regardless of how the entity publishes
+   them.
 
 4. **Registration**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Inmor Trust Anchor Documentation
 =================================
 
-Inmor is a Trust Anchor (TA) implementation for `OpenID Federation <https://openid.net/specs/openid-federation-1_0.html>`_ (Draft 46).
+Inmor is a Trust Anchor (TA) implementation for `OpenID Federation 1.0 <https://openid.net/specs/openid-federation-1_0.html>`_.
 It provides a complete solution for managing OpenID Federation trust chains, subordinate entities, and trust marks.
 
 The system consists of two components:

--- a/justfile
+++ b/justfile
@@ -85,11 +85,12 @@ rebuild-ta:
 up:
   {{dc}} up -d
 
+# To start only the db container, useful for running the collection walk locally
+up-db:
+  {{dc}} up -d db
+
 down:
   {{dc}} down
-
-logs:
-  {{dc}} logs -f 
 
 t-admin *FLAGS:
   {{dc}} exec admin pytest -vvv {{FLAGS}}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -633,6 +633,83 @@ pub fn get_jwks_from_payload(payload: &JwtPayload) -> Result<JwkSet> {
     Ok(JwkSet::from_map(internal_map)?)
 }
 
+/// Fetch a JWKS from a remote `jwks_uri` endpoint.
+///
+/// Uses the shared HTTP client with the same URL validation and size limits
+/// as other federation requests.
+pub async fn fetch_jwks_from_uri(uri: &str) -> Result<JwkSet> {
+    let body = get_query(uri).await?;
+    parse_jwks_json(&body).map_err(|e| anyhow!("Failed to parse JWKS from {}: {}", uri, e))
+}
+
+/// Fetch a JWKS from a URI with Redis caching.
+///
+/// Checks Redis for a cached copy first. On cache miss, fetches from the URI,
+/// stores in Redis with a 1-hour TTL, and returns the key set.
+pub async fn get_jwks_from_uri_cached(
+    uri: &str,
+    conn: &mut redis::aio::ConnectionManager,
+) -> Result<JwkSet> {
+    let hash = Sha256::digest(uri);
+    let cache_key = format!("inmor:jwks_cache:{:x}", hash);
+
+    // Try cache first
+    let cached: Option<String> = redis::Cmd::get(&cache_key)
+        .query_async(conn)
+        .await
+        .unwrap_or(None);
+
+    if let Some(ref cached_json) = cached {
+        return parse_jwks_json(cached_json);
+    }
+
+    // Cache miss — fetch from URI
+    let body = get_query(uri).await?;
+    let keyset = parse_jwks_json(&body)?;
+
+    // Store raw JSON in Redis with 1-hour TTL
+    let _: Result<(), _> = redis::Cmd::set_ex(&cache_key, &body, 3600)
+        .query_async(conn)
+        .await;
+
+    Ok(keyset)
+}
+
+/// Parse a JWKS JSON string into a JwkSet.
+fn parse_jwks_json(json_str: &str) -> Result<JwkSet> {
+    let parsed: Value =
+        serde_json::from_str(json_str).map_err(|e| anyhow!("Invalid JWKS JSON: {}", e))?;
+    let keys = parsed
+        .get("keys")
+        .ok_or_else(|| anyhow!("No 'keys' field in JWKS"))?;
+    let mut internal_map: Map<String, Value> = Map::new();
+    internal_map.insert("keys".to_string(), keys.clone());
+    Ok(JwkSet::from_map(internal_map)?)
+}
+
+/// Try to get JWKS from the payload's `jwks` claim, falling back to `jwks_uri`.
+///
+/// Priority: inline `jwks` > `jwks_uri`
+pub async fn get_jwks_from_payload_or_uri(
+    payload: &JwtPayload,
+    conn: &mut redis::aio::ConnectionManager,
+) -> Result<JwkSet> {
+    // Try inline jwks first
+    if let Ok(keyset) = get_jwks_from_payload(payload) {
+        return Ok(keyset);
+    }
+
+    // Fall back to jwks_uri
+    if let Some(uri_value) = payload.claim("jwks_uri")
+        && let Some(uri) = uri_value.as_str()
+    {
+        eprintln!("No inline jwks, fetching from jwks_uri: {}", uri);
+        return get_jwks_from_uri_cached(uri, conn).await;
+    }
+
+    Err(anyhow!("No jwks or jwks_uri found in payload"))
+}
+
 /// Gets the payload and header without any cryptographic verification.
 #[allow(clippy::explicit_counter_loop)]
 pub fn get_unverified_payload_header(data: &str) -> Result<(JwtPayload, JwsHeader)> {
@@ -741,6 +818,7 @@ pub async fn resolve_entity_to_trustanchor(
     start: bool,
     visited: &mut HashSet<String>,
     depth: u8,
+    redis_conn: &mut redis::aio::ConnectionManager,
 ) -> Result<Vec<VerifiedJWT>> {
     if depth > MAX_RESOLVE_DEPTH {
         bail!(
@@ -860,8 +938,8 @@ pub async fn resolve_entity_to_trustanchor(
                 // result a half done list back.
             }
         };
-        // Get the authority's JWKS and then verify the subordinate statement against them.
-        let ah_jwks = match get_jwks_from_payload(&ah_payload) {
+        // Get the authority's JWKS (inline, or via jwks_uri fallback) and verify the subordinate statement.
+        let ah_jwks = match get_jwks_from_payload_or_uri(&ah_payload, redis_conn).await {
             Ok(result) => result,
             Err(e) => {
                 eprintln!(
@@ -901,6 +979,7 @@ pub async fn resolve_entity_to_trustanchor(
                 false,
                 visited,
                 depth + 1,
+                redis_conn,
             ))
             .await?;
             if r_result.is_empty() {
@@ -959,7 +1038,7 @@ fn create_resolve_response_jwt(
 #[get("/resolve")]
 pub async fn resolve_entity(
     info: Query<ResolveParams>,
-    _redis: web::Data<redis::Client>,
+    redis: web::Data<redis::Client>,
     state: web::Data<AppState>,
 ) -> actix_web::Result<HttpResponse> {
     let mut found_ta = false;
@@ -970,14 +1049,19 @@ pub async fn resolve_entity(
     } = info.into_inner();
     let tas: Vec<&str> = trust_anchors.iter().map(|s| s as &str).collect();
     let mut visisted: HashSet<String> = HashSet::new();
+    let mut conn = redis
+        .get_connection_manager()
+        .await
+        .map_err(error::ErrorInternalServerError)?;
     // Now loop over the trust_anchors
-    let result = match resolve_entity_to_trustanchor(&sub, tas, true, &mut visisted, 0).await {
-        Ok(res) => res,
-        Err(e) => {
-            eprintln!("Error resolving entity {} to trust anchors: {}", sub, e);
-            return error_response_400("invalid_trust_chain", "Failed to find trust chain");
-        }
-    };
+    let result =
+        match resolve_entity_to_trustanchor(&sub, tas, true, &mut visisted, 0, &mut conn).await {
+            Ok(res) => res,
+            Err(e) => {
+                eprintln!("Error resolving entity {} to trust anchors: {}", sub, e);
+                return error_response_400("invalid_trust_chain", "Failed to find trust chain");
+            }
+        };
 
     // Verify that the result is not empty and we actually found a TA
     if result.is_empty() {
@@ -2020,5 +2104,49 @@ mod ssrf_tests {
             validate_entity_type("openid_provider; DROP TABLE keys"),
             Err("unknown entity type")
         );
+    }
+
+    #[test]
+    fn test_parse_jwks_json_valid() {
+        let json = r#"{"keys":[{"kty":"RSA","n":"test","e":"AQAB","kid":"k1"}]}"#;
+        let result = parse_jwks_json(json);
+        assert!(result.is_ok());
+        let keyset = result.unwrap();
+        assert!(!keyset.get("k1").is_empty());
+    }
+
+    #[test]
+    fn test_parse_jwks_json_no_keys_field() {
+        let json = r#"{"not_keys":[]}"#;
+        let result = parse_jwks_json(json);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No 'keys' field"));
+    }
+
+    #[test]
+    fn test_parse_jwks_json_invalid_json() {
+        let result = parse_jwks_json("not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_jwks_from_payload_missing_jwks() {
+        let payload = JwtPayload::new();
+        let result = get_jwks_from_payload(&payload);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No jwks"));
+    }
+
+    #[test]
+    fn test_get_jwks_from_payload_with_jwks() {
+        let mut payload = JwtPayload::new();
+        payload
+            .set_claim(
+                "jwks",
+                Some(json!({"keys":[{"kty":"RSA","n":"test","e":"AQAB","kid":"k1"}]})),
+            )
+            .unwrap();
+        let result = get_jwks_from_payload(&payload);
+        assert!(result.is_ok());
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -10,7 +10,9 @@ use std::collections::{HashMap, HashSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
-    EntityCollectionResponse, UiInfo, get_entity_configruation_as_jwt, get_query, self_verify_jwt,
+    EntityCollectionResponse, UiInfo, get_entity_configruation_as_jwt,
+    get_jwks_from_payload_or_uri, get_query, get_unverified_payload_header, self_verify_jwt,
+    verify_jwt_with_jwks,
 };
 
 /// Prefix for staging keys used during tree walk.
@@ -51,9 +53,30 @@ async fn fetch_all_subordinate_statements(
 
         let (entity_payload, _) = match self_verify_jwt(&jwt_net) {
             Ok(data) => data,
-            Err(e) => {
-                error!("Failed to verify authority hint JWT for {ahint_str}: {e}");
-                continue;
+            Err(_) => {
+                // Self-verification failed — try fetching JWKS from jwks_uri
+                let (unverified_payload, _) = match get_unverified_payload_header(&jwt_net) {
+                    Ok(data) => data,
+                    Err(e) => {
+                        error!("Failed to parse authority hint JWT for {ahint_str}: {e}");
+                        continue;
+                    }
+                };
+                match get_jwks_from_payload_or_uri(&unverified_payload, conn).await {
+                    Ok(keyset) => match verify_jwt_with_jwks(&jwt_net, Some(keyset)) {
+                        Ok(data) => data,
+                        Err(e) => {
+                            error!(
+                                "Failed to verify authority hint JWT for {ahint_str} with fetched JWKS: {e}"
+                            );
+                            continue;
+                        }
+                    },
+                    Err(e) => {
+                        error!("Failed to get JWKS for authority hint {ahint_str}: {e}");
+                        continue;
+                    }
+                }
             }
         };
 
@@ -199,9 +222,34 @@ async fn collection_tree_walking(
             debug!("JWT verification successful for {entity_id}");
             data
         }
-        Err(e) => {
-            error!("Failed to verify entity configuration for {entity_id}: {e}");
-            return;
+        Err(_) => {
+            // Self-verification failed — try fetching JWKS from jwks_uri
+            debug!("Self-verification failed for {entity_id}, trying jwks_uri fallback");
+            let (unverified_payload, _) = match get_unverified_payload_header(&jwt_net) {
+                Ok(data) => data,
+                Err(e) => {
+                    error!("Failed to parse entity configuration JWT for {entity_id}: {e}");
+                    return;
+                }
+            };
+            match get_jwks_from_payload_or_uri(&unverified_payload, conn).await {
+                Ok(keyset) => match verify_jwt_with_jwks(&jwt_net, Some(keyset)) {
+                    Ok(data) => {
+                        debug!("JWT verification successful for {entity_id} via jwks_uri");
+                        data
+                    }
+                    Err(e) => {
+                        error!(
+                            "Failed to verify entity configuration for {entity_id} with fetched JWKS: {e}"
+                        );
+                        return;
+                    }
+                },
+                Err(e) => {
+                    error!("Failed to get JWKS for entity {entity_id}: {e}");
+                    return;
+                }
+            }
         }
     };
 

--- a/tests/test_inmor.py
+++ b/tests/test_inmor.py
@@ -599,9 +599,7 @@ def test_resolve_rejects_private_ip(loaddata: Redis, start_server: int, http_cli
     assert resp.status_code == 400
 
 
-def test_resolve_timeout_on_unreachable(
-    loaddata: Redis, start_server: int, http_client: Client
-):
+def test_resolve_timeout_on_unreachable(loaddata: Redis, start_server: int, http_client: Client):
     """C2: Server does not hang indefinitely on unreachable entities."""
     _rdb = loaddata
     port = start_server


### PR DESCRIPTION
Fixes #212 add a two-level fallback chain (jwks -> jwks_uri) for resolving federation entity keys across both Rust and Python. Previously, the system required inline jwks in all entity configurations -> the /resolve endpoint silently skipped authorities without it, tree walking stopped at such entities, and Python's self_validate() crashed with an AttributeError.

Rust changes (src/lib.rs, src/tree.rs):
- Add fetch_jwks_from_uri(), parse_jwks_json(), and get_jwks_from_uri_cached() with Redis-backed caching (1h TTL)
- Add get_jwks_from_payload_or_uri() that tries inline jwks first, then fetches from jwks_uri
- Thread Redis connection through resolve_entity_to_trustanchor() so /resolve can fetch remote keys during chain walking
- Add jwks_uri fallback in tree walking when self-verification fails

Python changes (admin/entities/lib.py, admin/inmoradmin/api.py):
- Add fetch_jwks_from_uri() helper
- Fix self_validate() crash, add jwks_uri fallback
- Add jwks_uri to fetch-config API response schema
- Resolve jwks_uri server-side in fetch-config endpoint so the frontend always receives populated keys

Also adds unit tests for JWKS parsing and jwks_uri fallback in both Rust and Python, and ADR 0006 documenting the decision.