### PR TITLE
feat: verify trust marks in /resolve

### DIFF
--- a/admin/entities/lib.py
+++ b/admin/entities/lib.py
@@ -77,10 +77,35 @@ def create_server_statement() -> str:
     if len(tms) > 0:
         sub_data["trust_marks"] = tms
 
-    # Any trusted trustmark issuers
-    tm_trusted_issuers = settings.TA_TRUSTED_TRUSTMARK_ISSUERS
-    if len(tm_trusted_issuers) > 0:
-        sub_data["trust_mark_issuers"] = tm_trusted_issuers
+    # Any trusted trustmark issuers.
+    # Settings holds *external* issuers; the TA's own entity_id
+    # (settings.TRUSTMARK_PROVIDER, which is the `iss` of every trust mark this
+    # admin issues) is auto-included for every active TrustMarkType so that
+    # /resolve will recognise marks issued by this TA without operators having
+    # to restate that fact in localsettings.py.
+    #
+    # Per spec §3.1.2, an empty list for a type means "anyone may issue". We
+    # treat an explicit `{type: []}` in settings as a deliberate "open" marker
+    # and skip auto-include for that type — otherwise auto-include would flip
+    # the operator's intent from "any issuer" to "TA only".
+    from trustmarks.models import TrustMarkType
+
+    explicitly_open: set[str] = {
+        k for k, v in settings.TA_TRUSTED_TRUSTMARK_ISSUERS.items() if v == []
+    }
+    issuers: dict[str, list[str]] = {
+        k: list(v) for k, v in settings.TA_TRUSTED_TRUSTMARK_ISSUERS.items()
+    }
+    ta_issuer_id = settings.TRUSTMARK_PROVIDER
+    for tmt in TrustMarkType.objects.filter(active=True):
+        if tmt.tmtype in explicitly_open:
+            # Operator deliberately set [] for this type — preserve "any issuer".
+            continue
+        issuers.setdefault(tmt.tmtype, [])
+        if ta_issuer_id not in issuers[tmt.tmtype]:
+            issuers[tmt.tmtype].append(ta_issuer_id)
+    if issuers:
+        sub_data["trust_mark_issuers"] = issuers
 
     # Set creation and expiry time
     now = datetime.now()

--- a/admin/tests/test_entitylib.py
+++ b/admin/tests/test_entitylib.py
@@ -2,6 +2,7 @@ import json
 import os
 from typing import Any
 
+import pytest
 from django.test import TestCase
 from jwcrypto import jwt
 from jwcrypto.common import json_decode
@@ -26,3 +27,60 @@ def test_fetch_entity_configuration_with_keys():
     keys = metadata["openid_relying_party"]["jwks"]
     metadata.pop("openid_relying_party")
     _ = lib.fetch_entity_configuration("https://fakerp0.labb.sunet.se", keys)
+
+
+# ---------------------------------------------------------------------------
+# create_server_statement() — trust_mark_issuers auto-include semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_create_server_statement_auto_includes_ta_for_active_types(db_with_fixtures, settings):
+    "Active TrustMarkType rows get the TA's entity_id appended to trust_mark_issuers."
+    settings.TA_TRUSTED_TRUSTMARK_ISSUERS = {}
+
+    token = lib.create_server_statement()
+    payload = get_payload(token)
+
+    issuers = payload.get("trust_mark_issuers", {})
+    ta_id = settings.TRUSTMARK_PROVIDER
+    # Fixture has two active TrustMarkType rows.
+    assert "https://sunet.se/does_not_exist_trustmark" in issuers
+    assert "https://example.com/trust_mark_type" in issuers
+    for tmtype, allowed in issuers.items():
+        assert ta_id in allowed, f"TA must be in allowed list for {tmtype}"
+
+
+@pytest.mark.django_db
+def test_create_server_statement_preserves_explicit_empty_list(db_with_fixtures, settings):
+    "An explicit `{type: []}` in settings means 'anyone may issue' and must not be overridden."
+    open_type = "https://sunet.se/does_not_exist_trustmark"  # has a TrustMarkType row
+    settings.TA_TRUSTED_TRUSTMARK_ISSUERS = {open_type: []}
+
+    token = lib.create_server_statement()
+    payload = get_payload(token)
+
+    issuers = payload.get("trust_mark_issuers", {})
+    # The explicitly-open type must stay empty — auto-include would silently flip
+    # the spec §3.1.2 "anyone may issue" semantics to "TA only".
+    assert issuers.get(open_type) == [], (
+        f"explicit empty list for {open_type} must be preserved; got {issuers.get(open_type)!r}"
+    )
+
+
+@pytest.mark.django_db
+def test_create_server_statement_merges_external_issuers_with_ta(db_with_fixtures, settings):
+    "Settings-provided external issuers are kept; TA is appended for active types."
+    tmtype = "https://example.com/trust_mark_type"  # has a TrustMarkType row
+    external = "https://external-issuer.example.com"
+    settings.TA_TRUSTED_TRUSTMARK_ISSUERS = {tmtype: [external]}
+
+    token = lib.create_server_statement()
+    payload = get_payload(token)
+
+    issuers = payload.get("trust_mark_issuers", {})
+    allowed = issuers.get(tmtype, [])
+    assert external in allowed, "external issuer from settings must survive"
+    assert settings.TRUSTMARK_PROVIDER in allowed, (
+        "TA must still be appended for an active TrustMarkType"
+    )

--- a/docs/guides/trustmarks.rst
+++ b/docs/guides/trustmarks.rst
@@ -341,6 +341,77 @@ Configure these in ``localsettings.py``:
 
 These trust marks appear in the TA's entity configuration (``/.well-known/openid-federation``).
 
+Trusted Trust Mark Issuers (Federation Recognition)
+---------------------------------------------------
+
+OpenID Federation §3.1.2 defines the ``trust_mark_issuers`` claim on a Trust
+Anchor's entity configuration. It tells the federation which combinations of
+trust mark type and issuer are recognised. Inmor publishes this claim on
+``/.well-known/openid-federation`` and uses it during ``/resolve`` (§8.3) to
+decide which trust marks may be included in the resolve response.
+
+The recognised list is built from two sources:
+
+1. **External issuers** — configured via ``TA_TRUSTED_TRUSTMARK_ISSUERS`` in
+   ``localsettings.py`` (a Python ``dict[str, list[str]]`` mapping trust mark
+   type URL to a list of allowed issuer entity IDs). This is the authoritative
+   source for issuers other than this TA itself.
+2. **Self-issuance** — for every active ``TrustMarkType`` row in the admin
+   database, this TA's own entity ID
+   (``settings.TRUSTMARK_PROVIDER`` — the ``iss`` of every trust mark issued
+   by this admin) is appended automatically. Operators do not need to restate
+   this in ``localsettings.py``.
+
+.. code-block:: python
+
+   # localsettings.py — only external issuers go here
+   TA_TRUSTED_TRUSTMARK_ISSUERS = {
+       "https://refeds.org/trustmarks/sirtfi": ["https://swamid.se"],
+       "https://openid.net/certification/op": [],   # any issuer (per §3.1.2)
+   }
+
+After changing this setting (or after adding/removing ``TrustMarkType`` rows),
+run the management command to refresh the published entity configuration:
+
+.. code-block:: bash
+
+   docker compose exec admin python manage.py regenerate_entity
+
+Per spec §3.1.2, an empty list for a given type means "anyone may issue trust
+marks with that identifier"; signature, expiry, and (for external issuers)
+revocation status are still verified.
+
+How ``/resolve`` Uses the List
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For every trust mark on a resolved subject, the Rust TA:
+
+1. Skips the mark if its ``trust_mark_type`` is not a key in
+   ``trust_mark_issuers``.
+2. Skips the mark if its ``iss`` is not in the allowed list for that type
+   (empty list bypasses this check).
+3. **For TA-issued marks** (``iss`` equals this TA): verifies the signature
+   against this TA's public keyset and checks Redis for a revocation entry.
+4. **For external-issued marks**: fetches the issuer's entity configuration,
+   discovers the issuer's
+   ``federation_trust_mark_status_endpoint`` from its ``federation_entity``
+   metadata, ``POST``\ s the trust mark to that endpoint, and verifies the
+   response JWT signature against the issuer's JWKS. The mark is included
+   only if the response's ``status`` claim is ``"active"``.
+
+The behaviour is **fail-closed**: any error (network failure, missing status
+endpoint, signature failure, non-active status, malformed JWT) causes that
+single trust mark to be omitted from the resolve response. The rest of the
+resolve still succeeds. Skipped marks are logged at WARN.
+
+If an external issuer does **not** advertise
+``federation_trust_mark_status_endpoint``, marks issued by it will be silently
+excluded. Issuers that want their marks honoured by Inmor MUST publish a
+status endpoint (per spec §8.4.1).
+
+The resolve response's ``exp`` claim is the minimum of every trust chain
+``exp`` and every included trust mark's ``exp`` (per spec §8.3.2).
+
 Best Practices
 --------------
 

--- a/docs/guides/trustmarks.rst
+++ b/docs/guides/trustmarks.rst
@@ -405,9 +405,10 @@ single trust mark to be omitted from the resolve response. The rest of the
 resolve still succeeds. Skipped marks are logged at WARN.
 
 If an external issuer does **not** advertise
-``federation_trust_mark_status_endpoint``, marks issued by it will be silently
-excluded. Issuers that want their marks honoured by Inmor MUST publish a
-status endpoint (per spec §8.4.1).
+``federation_trust_mark_status_endpoint``, marks issued by it are omitted from
+the resolve response (and logged at WARN, like every other skipped mark).
+Issuers that want their marks honoured by Inmor MUST publish a status endpoint
+(per spec §8.4.1).
 
 The resolve response's ``exp`` claim is the minimum of every trust chain
 ``exp`` and every included trust mark's ``exp`` (per spec §8.3.2).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ pub mod tree;
 use anyhow::{Result, anyhow, bail};
 
 use lazy_static::lazy_static;
-use log::debug;
+use log::{debug, warn};
 use sha2::{Digest, Sha256};
 use std::fmt::Display;
 use std::net::IpAddr;
@@ -812,6 +812,19 @@ pub fn self_verify_jwt(data: &str) -> Result<(JwtPayload, JwsHeader)> {
 /// Practical federations rarely exceed 3-4 levels.
 const MAX_RESOLVE_DEPTH: u8 = 10;
 
+/// Maximum number of trust marks the resolver will verify per /resolve request.
+/// Each external-issued mark may trigger up to two outbound HTTP requests
+/// (each capped by `HTTP_CLIENT`'s 10s timeout); an attacker-controlled subject
+/// entity configuration can otherwise embed hundreds of marks and stall an
+/// actix worker. Practical entities carry a handful of marks.
+const MAX_TRUST_MARKS_PER_RESOLVE: usize = 32;
+
+/// Total wall-clock budget for the trust-mark verification phase of /resolve.
+/// Bounds worst-case worker-thread time even when every mark hits its per-request
+/// timeout. The budget intentionally exceeds a single mark's worst-case latency
+/// (~20s) so a single slow issuer doesn't starve the rest.
+const TRUST_MARK_VERIFICATION_BUDGET_SECS: u64 = 30;
+
 pub async fn resolve_entity_to_trustanchor(
     sub: &str,
     trust_anchors: Vec<&str>,
@@ -1003,6 +1016,7 @@ fn create_resolve_response_jwt(
     sub: &str,
     result: &[VerifiedJWT],
     metadata: Option<Map<String, Value>>,
+    trust_marks: Option<Vec<Value>>,
 ) -> Result<String, JoseError> {
     let mut payload = JwtPayload::new();
     let iss = state.entity_id.clone();
@@ -1014,9 +1028,16 @@ fn create_resolve_response_jwt(
     // the Trust Chain from which the resolve response was derived, as well as
     // any Trust Mark included in the response."
     let fallback_exp = SystemTime::now() + Duration::from_secs(86400);
-    let min_exp = result
-        .iter()
-        .filter_map(|v| v.payload.expires_at())
+    let chain_exp_iter = result.iter().filter_map(|v| v.payload.expires_at());
+    let trust_mark_exp_iter = trust_marks.as_ref().into_iter().flat_map(|tms| {
+        tms.iter().filter_map(|tm| {
+            let jwt_str = tm.get("trust_mark")?.as_str()?;
+            let (tm_payload, _) = get_unverified_payload_header(jwt_str).ok()?;
+            tm_payload.expires_at()
+        })
+    });
+    let min_exp = chain_exp_iter
+        .chain(trust_mark_exp_iter)
         .min()
         .unwrap_or(fallback_exp);
     payload.set_expires_at(&min_exp);
@@ -1027,11 +1048,381 @@ fn create_resolve_response_jwt(
     let trust_chain: Vec<String> = result.iter().map(|x| x.jwt.clone()).collect();
     let _ = payload.set_claim("trust_chain", Some(json!(trust_chain)));
 
+    if let Some(tms) = trust_marks
+        && !tms.is_empty()
+    {
+        let _ = payload.set_claim("trust_marks", Some(json!(tms)));
+    }
+
     // Signing JWT
     let keydata = &*PRIVATE_KEY.clone();
     let key = Jwk::from_bytes(keydata)?;
 
     create_signed_jwt(&payload, &key, Some("resolve-response+jwt"))
+}
+
+/// Verify a trust mark JWT issued by *this* TA.
+///
+/// Returns `true` only when all of the following hold:
+/// 1. SHA256 of the JWT exists in `inmor:tm:alltime` (it was actually issued by us).
+/// 2. The JWT signature, `exp`, `nbf`, and `iat` validate against the TA's public keyset.
+/// 3. `inmor:tm:{sub}` HGET for `trust_mark_type` is not `"revoked"`.
+///
+/// Any error (Redis failure, signature failure, expiry, missing fields) returns `false`.
+/// Mirrors the active-status decision in `trust_mark_status` (Section 8.4.1).
+async fn verify_ta_issued_trust_mark(
+    trust_mark_jwt: &str,
+    ta_public_keyset: &JwkSet,
+    conn: &mut redis::aio::ConnectionManager,
+) -> bool {
+    // 1. Was this mark ever issued by us?
+    let mut hasher = Sha256::new();
+    hasher.update(trust_mark_jwt.as_bytes());
+    let hash = format!("{:x}", hasher.finalize());
+    match redis::Cmd::sismember("inmor:tm:alltime", &hash)
+        .query_async::<bool>(conn)
+        .await
+    {
+        Ok(true) => {}
+        Ok(false) => {
+            warn!("trust mark not in inmor:tm:alltime; hash={hash}");
+            return false;
+        }
+        Err(e) => {
+            warn!("redis SISMEMBER failed for {hash}: {e}");
+            return false;
+        }
+    }
+
+    // 2. Signature, exp, nbf, iat — all enforced by verify_jwt_with_jwks.
+    let (payload, _header) =
+        match verify_jwt_with_jwks(trust_mark_jwt, Some(ta_public_keyset.clone())) {
+            Ok(p) => p,
+            Err(e) => {
+                warn!("trust mark signature/temporal verification failed (hash={hash}): {e}");
+                return false;
+            }
+        };
+
+    // 3. Revocation lookup.
+    let sub = payload.subject().unwrap_or("");
+    let trust_mark_type = payload
+        .claim("trust_mark_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if validate_redis_key_input(sub).is_err() || validate_redis_key_input(trust_mark_type).is_err()
+    {
+        warn!("trust mark sub or trust_mark_type fails Redis key validation; hash={hash}");
+        return false;
+    }
+    let hkey = format!("inmor:tm:{sub}");
+    match redis::Cmd::hget(hkey, trust_mark_type)
+        .query_async::<String>(conn)
+        .await
+    {
+        Ok(mark) => mark != "revoked",
+        Err(e) => {
+            warn!("redis HGET inmor:tm:{sub} {trust_mark_type} failed: {e}");
+            false
+        }
+    }
+}
+
+/// Verify a single trust mark from a subject's entity configuration.
+///
+/// If the mark was issued by this TA (`issuer == ta_entity_id`), this delegates to
+/// `verify_ta_issued_trust_mark` (local Redis + signature). Otherwise it calls the
+/// issuer's `federation_trust_mark_status_endpoint` (per spec §8.4.1) and accepts
+/// the mark only if the response JWT's signature verifies against the issuer's JWKS
+/// AND its `status` claim is `"active"`.
+///
+/// Fail-closed at every step: any network error, parse error, signature failure,
+/// missing endpoint, or non-active status returns `false` and logs at WARN.
+async fn verify_single_trust_mark(
+    trust_mark_jwt: &str,
+    issuer: &str,
+    ta_entity_id: &str,
+    ta_public_keyset: &JwkSet,
+    conn: &mut redis::aio::ConnectionManager,
+) -> bool {
+    if issuer == ta_entity_id {
+        return verify_ta_issued_trust_mark(trust_mark_jwt, ta_public_keyset, conn).await;
+    }
+
+    // External issuer path.
+    // 1. Fetch the issuer's entity configuration over the SSRF-safe path.
+    let ec_jwt = match get_entity_configruation_as_jwt(issuer).await {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("trust mark: failed to fetch entity configuration for issuer {issuer}: {e}");
+            return false;
+        }
+    };
+
+    // 2. Resolve the issuer's JWKS (inline `jwks` claim or, when only the
+    //    `jwks_uri` claim is present, fetch and cache via Redis). We need the
+    //    unverified payload here just to read those claims; the actual
+    //    signature check happens in step 3 once we have the JWKS.
+    let (ec_payload_unverified, _) = match get_unverified_payload_header(&ec_jwt) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("trust mark: failed to parse entity configuration for issuer {issuer}: {e}");
+            return false;
+        }
+    };
+    let issuer_jwks = match get_jwks_from_payload_or_uri(&ec_payload_unverified, conn).await {
+        Ok(j) => j,
+        Err(e) => {
+            warn!("trust mark: failed to obtain JWKS for issuer {issuer}: {e}");
+            return false;
+        }
+    };
+
+    // 3. Verify the entity configuration signature against the resolved JWKS
+    //    (also enforces exp/nbf/iat temporal claims).
+    let (ec_payload, _) = match verify_jwt_with_jwks(&ec_jwt, Some(issuer_jwks.clone())) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                "trust mark: entity configuration signature/temporal verification failed for issuer {issuer}: {e}"
+            );
+            return false;
+        }
+    };
+
+    // 4. Find the issuer's trust mark status endpoint.
+    let status_endpoint = match ec_payload
+        .claim("metadata")
+        .and_then(|m| m.get("federation_entity"))
+        .and_then(|fe| fe.get("federation_trust_mark_status_endpoint"))
+        .and_then(|e| e.as_str())
+    {
+        Some(s) => s.to_string(),
+        None => {
+            warn!(
+                "trust mark: issuer {issuer} does not advertise federation_trust_mark_status_endpoint; skipping"
+            );
+            return false;
+        }
+    };
+
+    // 5. POST the trust mark to the status endpoint.
+    let response_jwt =
+        match post_form_query(&status_endpoint, &[("trust_mark", trust_mark_jwt)]).await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("trust mark: POST {status_endpoint} failed: {e}");
+                return false;
+            }
+        };
+
+    // 6. Verify signature and temporal claims of the status response.
+    let (status_payload, _) = match verify_jwt_with_jwks(&response_jwt, Some(issuer_jwks)) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                "trust mark: status response from {issuer} failed signature/temporal verification: {e}"
+            );
+            return false;
+        }
+    };
+
+    // 7. Defense-in-depth: bind the status response to the request and the
+    //    queried issuer. Without these, a buggy or compromised issuer could
+    //    return a cached "active" response for a *different* mark, or a JWT
+    //    whose `iss` doesn't match the issuer whose keys we just trusted.
+    let echoed_trust_mark = status_payload
+        .claim("trust_mark")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if echoed_trust_mark != trust_mark_jwt {
+        warn!(
+            "trust mark: status response from {issuer} echoed a different `trust_mark` claim; skipping"
+        );
+        return false;
+    }
+    if status_payload.issuer() != Some(issuer) {
+        warn!(
+            "trust mark: status response `iss` ({:?}) does not match queried issuer {issuer}; skipping",
+            status_payload.issuer()
+        );
+        return false;
+    }
+
+    // 8. Inspect the `status` claim. Anything other than "active" → skip.
+    let status = status_payload
+        .claim("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if status != "active" {
+        warn!("trust mark: issuer {issuer} reported status='{status}'; skipping");
+        return false;
+    }
+
+    true
+}
+
+/// Verify every trust mark on a subject and return the subset that the federation
+/// recognises and which are currently active.
+///
+/// Reads the TA's own entity configuration from Redis (`inmor:entity_id`) to get
+/// the `trust_mark_issuers` claim — the federation-wide trusted issuer list (per
+/// spec §3.1.2). For each entry in the subject's `trust_marks` array:
+///
+/// * Skip if the mark's `trust_mark_type` is not a key in `trust_mark_issuers`.
+/// * If the allowed-issuer list for that type is empty, any issuer is acceptable
+///   (per spec §3.1.2: "anyone MAY issue Trust Marks with that identifier").
+/// * Otherwise, the unverified `iss` from the trust mark JWT must appear in the
+///   list.
+/// * Finally, `verify_single_trust_mark` must report `true`.
+///
+/// The original `{trust_mark, trust_mark_type}` objects are returned unchanged so
+/// they can be embedded verbatim in the resolve response (per spec §8.3.2).
+async fn verify_trust_marks_for_resolve(
+    subject_payload: &JwtPayload,
+    ta_entity_id: &str,
+    ta_public_keyset: &JwkSet,
+    conn: &mut redis::aio::ConnectionManager,
+) -> Vec<Value> {
+    // 1. Subject's trust marks.
+    let trust_marks = match subject_payload
+        .claim("trust_marks")
+        .and_then(|v| v.as_array())
+    {
+        Some(arr) if !arr.is_empty() => arr.clone(),
+        _ => return Vec::new(),
+    };
+    // The resolved subject's own entity_id — used to drop marks that were
+    // issued to a *different* entity (spec §7.4: the trust mark's `sub` claim
+    // is the entity the mark is issued to). Without this, an entity could
+    // republish another's mark in its own `trust_marks` array and have it
+    // accepted as its own.
+    let resolve_sub = subject_payload.subject().unwrap_or("");
+
+    // 2. TA's own entity configuration → trust_mark_issuers map.
+    let ta_ec_jwt: String = match redis::Cmd::get("inmor:entity_id")
+        .query_async::<String>(conn)
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("trust mark resolve: failed to GET inmor:entity_id from Redis: {e}");
+            return Vec::new();
+        }
+    };
+    // We trust Redis here — it's our own data written by the admin process.
+    // Skipping the signature check is intentional: it avoids a needless self-verify
+    // on every resolve and matches the trust boundary used by other endpoints that
+    // read `inmor:entity_id`.
+    let (ta_payload, _) = match get_unverified_payload_header(&ta_ec_jwt) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("trust mark resolve: failed to parse TA entity configuration: {e}");
+            return Vec::new();
+        }
+    };
+    let trust_mark_issuers = match ta_payload
+        .claim("trust_mark_issuers")
+        .and_then(|v| v.as_object())
+    {
+        Some(obj) => obj.clone(),
+        None => {
+            // No `trust_mark_issuers` claim → no recognised types in this federation.
+            return Vec::new();
+        }
+    };
+
+    // 3. Filter and verify each mark.
+    //
+    // Hard cap: bounds the per-request HTTP fan-out (each external mark may
+    // trigger two outbound calls). See MAX_TRUST_MARKS_PER_RESOLVE.
+    if trust_marks.len() > MAX_TRUST_MARKS_PER_RESOLVE {
+        warn!(
+            "subject has {} trust marks; processing only the first {}",
+            trust_marks.len(),
+            MAX_TRUST_MARKS_PER_RESOLVE
+        );
+    }
+
+    let mut verified: Vec<Value> = Vec::new();
+    for tm in trust_marks.iter().take(MAX_TRUST_MARKS_PER_RESOLVE) {
+        let tm_obj = match tm.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+        let jwt_str = match tm_obj.get("trust_mark").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => continue,
+        };
+        let tm_type = match tm_obj.get("trust_mark_type").and_then(|v| v.as_str()) {
+            Some(s) => s,
+            None => continue,
+        };
+
+        let allowed = match trust_mark_issuers.get(tm_type).and_then(|v| v.as_array()) {
+            Some(a) => a,
+            None => continue, // type not recognised by federation
+        };
+
+        let (unverified_payload, _) = match get_unverified_payload_header(jwt_str) {
+            Ok(p) => p,
+            Err(e) => {
+                warn!("trust mark resolve: failed to parse trust mark JWT: {e}");
+                continue;
+            }
+        };
+
+        // Spec §7.4: the outer `trust_mark_type` MUST equal the JWT's inner
+        // `trust_mark_type` claim. Drop the mark on mismatch to avoid emitting
+        // a self-contradictory entry in the resolve response. Comparing the
+        // unverified inner claim is safe — the inner bytes are part of the
+        // signed payload, so any divergence between this value and what
+        // `verify_single_trust_mark` would later see is impossible.
+        let inner_tm_type = unverified_payload
+            .claim("trust_mark_type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if inner_tm_type != tm_type {
+            warn!(
+                "trust mark resolve: outer trust_mark_type {tm_type} != inner {inner_tm_type} (spec §7.4); skipping"
+            );
+            continue;
+        }
+
+        // Spec §7.4: the trust mark's `sub` is the entity to which the mark
+        // is issued. A mark whose inner `sub` doesn't match the entity we're
+        // resolving belongs to someone else and must not appear here.
+        let mark_sub = unverified_payload.subject().unwrap_or("");
+        if mark_sub != resolve_sub {
+            warn!(
+                "trust mark resolve: trust mark sub {mark_sub} != resolved subject {resolve_sub}; skipping"
+            );
+            continue;
+        }
+
+        let issuer = unverified_payload.issuer().unwrap_or("").to_string();
+        if issuer.is_empty() {
+            warn!("trust mark resolve: trust mark JWT has empty `iss`");
+            continue;
+        }
+
+        // Empty allowed list = any issuer (per spec §3.1.2).
+        if !allowed.is_empty() {
+            let issuer_ok = allowed.iter().any(|v| v.as_str() == Some(issuer.as_str()));
+            if !issuer_ok {
+                warn!(
+                    "trust mark resolve: issuer {issuer} not in allowed list for type {tm_type}; skipping"
+                );
+                continue;
+            }
+        }
+
+        if verify_single_trust_mark(jwt_str, &issuer, ta_entity_id, ta_public_keyset, conn).await {
+            verified.push(tm.clone());
+        }
+    }
+
+    verified
 }
 
 /// https://openid.net/specs/openid-federation-1_0.html#name-resolve-request
@@ -1077,6 +1468,39 @@ pub async fn resolve_entity(
         eprintln!("No trust anchor found in chain for entity: {}", sub);
         return error_response_400("invalid_trust_chain", "Failed to find trust chain");
     }
+
+    // Per spec §8.3: "The resolver MUST verify that all present Trust Marks with
+    // identifiers recognized within the Federation are active. The response set
+    // MUST include only verified Trust Marks." `result[0]` is the subject's own
+    // entity configuration (the chain runs subject → ... → TA).
+    //
+    // The whole phase runs under a wall-clock budget — combined with
+    // MAX_TRUST_MARKS_PER_RESOLVE, this bounds the worst-case worker-thread
+    // time a malicious subject EC can cause.
+    let verified_trust_marks = match tokio::time::timeout(
+        Duration::from_secs(TRUST_MARK_VERIFICATION_BUDGET_SECS),
+        verify_trust_marks_for_resolve(
+            &result[0].payload,
+            &state.entity_id,
+            &state.public_keyset,
+            &mut conn,
+        ),
+    )
+    .await
+    {
+        Ok(marks) => marks,
+        Err(_) => {
+            warn!(
+                "trust mark verification exceeded {TRUST_MARK_VERIFICATION_BUDGET_SECS}s budget for sub={sub}; returning none"
+            );
+            Vec::new()
+        }
+    };
+    let trust_marks = if verified_trust_marks.is_empty() {
+        None
+    } else {
+        Some(verified_trust_marks)
+    };
 
     let mut mpolicy: Option<Map<String, Value>> = None;
     let reversed: Vec<&VerifiedJWT> = result.iter().rev().collect();
@@ -1205,7 +1629,7 @@ pub async fn resolve_entity(
     let filtered_metadata = filter_metadata_by_entity_types(mpolicy, entity_type.as_ref());
 
     // If we reach here means we have a list of JWTs and also verified metadata.
-    let resp = create_resolve_response_jwt(&state, &sub, &result, filtered_metadata)
+    let resp = create_resolve_response_jwt(&state, &sub, &result, filtered_metadata, trust_marks)
         .map_err(error::ErrorInternalServerError)?;
     Ok(HttpResponse::Ok()
         .insert_header(("content-type", "application/resolve-response+jwt"))
@@ -1608,6 +2032,38 @@ async fn validate_federation_url(url_str: &str, allow_http: bool) -> Result<()> 
     }
 
     Ok(())
+}
+
+/// To do a POST with `application/x-www-form-urlencoded` body. Uses the same SSRF gate,
+/// shared HTTP client (timeouts/redirect limit/pool), and `MAX_RESPONSE_BYTES` cap as
+/// `get_query`. Used to call external trust mark issuers' `/trust_mark_status` endpoint.
+pub async fn post_form_query(url: &str, form: &[(&str, &str)]) -> Result<String> {
+    validate_federation_url(url, ALLOW_HTTP.load(std::sync::atomic::Ordering::Relaxed)).await?;
+    let response = HTTP_CLIENT.post(url).form(form).send().await?;
+    if !response.status().is_success() {
+        bail!("POST to '{}' returned status {}", url, response.status());
+    }
+    if let Some(len) = response.content_length()
+        && len > MAX_RESPONSE_BYTES as u64
+    {
+        bail!(
+            "Response too large ({} bytes) from '{}', max {} bytes",
+            len,
+            url,
+            MAX_RESPONSE_BYTES
+        );
+    }
+    let bytes = response.bytes().await?;
+    if bytes.len() > MAX_RESPONSE_BYTES {
+        bail!(
+            "Response too large ({} bytes) from '{}', max {} bytes",
+            bytes.len(),
+            url,
+            MAX_RESPONSE_BYTES
+        );
+    }
+    String::from_utf8(bytes.to_vec())
+        .map_err(|e| anyhow!("Response from '{}' is not valid UTF-8: {}", url, e))
 }
 
 /// To do a GET query. Uses the shared HTTP client with timeouts and connection limits.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1128,34 +1128,36 @@ async fn verify_ta_issued_trust_mark(
     }
 }
 
-/// Verify a single trust mark from a subject's entity configuration.
-///
-/// If the mark was issued by this TA (`issuer == ta_entity_id`), this delegates to
-/// `verify_ta_issued_trust_mark` (local Redis + signature). Otherwise it calls the
-/// issuer's `federation_trust_mark_status_endpoint` (per spec §8.4.1) and accepts
-/// the mark only if the response JWT's signature verifies against the issuer's JWKS
-/// AND its `status` claim is `"active"`.
-///
-/// Fail-closed at every step: any network error, parse error, signature failure,
-/// missing endpoint, or non-active status returns `false` and logs at WARN.
-async fn verify_single_trust_mark(
-    trust_mark_jwt: &str,
-    issuer: &str,
-    ta_entity_id: &str,
-    ta_public_keyset: &JwkSet,
-    conn: &mut redis::aio::ConnectionManager,
-) -> bool {
-    if issuer == ta_entity_id {
-        return verify_ta_issued_trust_mark(trust_mark_jwt, ta_public_keyset, conn).await;
-    }
+/// Cached per-issuer data resolved during one /resolve invocation.
+#[derive(Clone)]
+struct IssuerInfo {
+    jwks: JwkSet,
+    status_endpoint: String,
+}
 
-    // External issuer path.
+/// Memoizes external-issuer lookups for the duration of a single /resolve call.
+///
+/// A subject can carry several marks from the same issuer; without this each
+/// would refetch the issuer's entity configuration (and possibly its
+/// `jwks_uri`) — burning the 30s trust-mark wall-clock budget on duplicate
+/// work. `None` caches a prior failure so we don't retry within the request.
+type IssuerInfoCache = HashMap<String, Option<IssuerInfo>>;
+
+/// Fetch + verify an external issuer's entity configuration, returning the data
+/// needed to call its trust-mark-status endpoint.
+///
+/// Returns `None` (and logs at WARN) on any failure: fetch error, parse error,
+/// JWKS resolution failure, signature failure, or missing status endpoint.
+async fn resolve_external_issuer(
+    issuer: &str,
+    conn: &mut redis::aio::ConnectionManager,
+) -> Option<IssuerInfo> {
     // 1. Fetch the issuer's entity configuration over the SSRF-safe path.
     let ec_jwt = match get_entity_configruation_as_jwt(issuer).await {
         Ok(s) => s,
         Err(e) => {
             warn!("trust mark: failed to fetch entity configuration for issuer {issuer}: {e}");
-            return false;
+            return None;
         }
     };
 
@@ -1167,14 +1169,14 @@ async fn verify_single_trust_mark(
         Ok(p) => p,
         Err(e) => {
             warn!("trust mark: failed to parse entity configuration for issuer {issuer}: {e}");
-            return false;
+            return None;
         }
     };
     let issuer_jwks = match get_jwks_from_payload_or_uri(&ec_payload_unverified, conn).await {
         Ok(j) => j,
         Err(e) => {
             warn!("trust mark: failed to obtain JWKS for issuer {issuer}: {e}");
-            return false;
+            return None;
         }
     };
 
@@ -1186,7 +1188,7 @@ async fn verify_single_trust_mark(
             warn!(
                 "trust mark: entity configuration signature/temporal verification failed for issuer {issuer}: {e}"
             );
-            return false;
+            return None;
         }
     };
 
@@ -1202,22 +1204,90 @@ async fn verify_single_trust_mark(
             warn!(
                 "trust mark: issuer {issuer} does not advertise federation_trust_mark_status_endpoint; skipping"
             );
+            return None;
+        }
+    };
+
+    Some(IssuerInfo {
+        jwks: issuer_jwks,
+        status_endpoint,
+    })
+}
+
+/// Verify a single trust mark from a subject's entity configuration.
+///
+/// If the mark was issued by this TA (`issuer == ta_entity_id`), this delegates to
+/// `verify_ta_issued_trust_mark` (local Redis + signature). Otherwise it:
+///
+/// 1. Resolves the issuer's JWKS + status endpoint (memoized in `issuer_cache`).
+/// 2. Verifies the trust-mark JWT itself (signature + exp/nbf/iat) against the
+///    issuer's JWKS. Without this step the resolve-response `exp` calculation
+///    would fold in an attacker-controlled `exp` claim from an unverified JWT,
+///    and a malformed mark whose status endpoint happens to misbehave could
+///    still slip through.
+/// 3. POSTs the mark to the issuer's `federation_trust_mark_status_endpoint`
+///    (spec §8.4.1) and accepts the mark only if the response JWT verifies
+///    against the same JWKS, its `trust_mark` claim echoes back the posted JWT,
+///    its `iss` matches the queried issuer, and `status == "active"`.
+///
+/// Fail-closed at every step: any network error, parse error, signature failure,
+/// missing endpoint, or non-active status returns `false` and logs at WARN.
+async fn verify_single_trust_mark(
+    trust_mark_jwt: &str,
+    issuer: &str,
+    ta_entity_id: &str,
+    ta_public_keyset: &JwkSet,
+    conn: &mut redis::aio::ConnectionManager,
+    issuer_cache: &mut IssuerInfoCache,
+) -> bool {
+    if issuer == ta_entity_id {
+        return verify_ta_issued_trust_mark(trust_mark_jwt, ta_public_keyset, conn).await;
+    }
+
+    // 1. Resolve the issuer's JWKS + status endpoint, caching per /resolve.
+    let issuer_info = if let Some(cached) = issuer_cache.get(issuer) {
+        match cached {
+            Some(info) => info.clone(),
+            None => return false, // cached failure
+        }
+    } else {
+        let resolved = resolve_external_issuer(issuer, conn).await;
+        issuer_cache.insert(issuer.to_string(), resolved.clone());
+        match resolved {
+            Some(info) => info,
+            None => return false,
+        }
+    };
+
+    // 2. Verify the trust mark JWT itself against the issuer's JWKS. This
+    //    enforces signature + exp/nbf/iat *before* the network round-trip and
+    //    before its `exp` is folded into the resolve-response `exp`.
+    if let Err(e) = verify_jwt_with_jwks(trust_mark_jwt, Some(issuer_info.jwks.clone())) {
+        warn!(
+            "trust mark: JWT signature/temporal verification failed against issuer {issuer} JWKS: {e}"
+        );
+        return false;
+    }
+
+    // 3. POST the trust mark to the status endpoint.
+    let response_jwt = match post_form_query(
+        &issuer_info.status_endpoint,
+        &[("trust_mark", trust_mark_jwt)],
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                "trust mark: POST {} failed: {e}",
+                issuer_info.status_endpoint
+            );
             return false;
         }
     };
 
-    // 5. POST the trust mark to the status endpoint.
-    let response_jwt =
-        match post_form_query(&status_endpoint, &[("trust_mark", trust_mark_jwt)]).await {
-            Ok(s) => s,
-            Err(e) => {
-                warn!("trust mark: POST {status_endpoint} failed: {e}");
-                return false;
-            }
-        };
-
-    // 6. Verify signature and temporal claims of the status response.
-    let (status_payload, _) = match verify_jwt_with_jwks(&response_jwt, Some(issuer_jwks)) {
+    // 4. Verify signature and temporal claims of the status response.
+    let (status_payload, _) = match verify_jwt_with_jwks(&response_jwt, Some(issuer_info.jwks)) {
         Ok(p) => p,
         Err(e) => {
             warn!(
@@ -1227,7 +1297,7 @@ async fn verify_single_trust_mark(
         }
     };
 
-    // 7. Defense-in-depth: bind the status response to the request and the
+    // 5. Defense-in-depth: bind the status response to the request and the
     //    queried issuer. Without these, a buggy or compromised issuer could
     //    return a cached "active" response for a *different* mark, or a JWT
     //    whose `iss` doesn't match the issuer whose keys we just trusted.
@@ -1249,7 +1319,7 @@ async fn verify_single_trust_mark(
         return false;
     }
 
-    // 8. Inspect the `status` claim. Anything other than "active" → skip.
+    // 6. Inspect the `status` claim. Anything other than "active" → skip.
     let status = status_payload
         .claim("status")
         .and_then(|v| v.as_str())
@@ -1345,6 +1415,10 @@ async fn verify_trust_marks_for_resolve(
     }
 
     let mut verified: Vec<Value> = Vec::new();
+    // Per-resolve memoization for external issuers. A subject can carry several
+    // marks from the same issuer; without this we'd refetch the issuer EC (and
+    // potentially its `jwks_uri`) once per mark and burn the 30s budget.
+    let mut issuer_cache: IssuerInfoCache = HashMap::new();
     for tm in trust_marks.iter().take(MAX_TRUST_MARKS_PER_RESOLVE) {
         let tm_obj = match tm.as_object() {
             Some(o) => o,
@@ -1417,7 +1491,16 @@ async fn verify_trust_marks_for_resolve(
             }
         }
 
-        if verify_single_trust_mark(jwt_str, &issuer, ta_entity_id, ta_public_keyset, conn).await {
+        if verify_single_trust_mark(
+            jwt_str,
+            &issuer,
+            ta_entity_id,
+            ta_public_keyset,
+            conn,
+            &mut issuer_cache,
+        )
+        .await
+        {
             verified.push(tm.clone());
         }
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
+import http.server
 import os
 import subprocess
 import tempfile
+import threading
 import time
 
 import httpx
@@ -37,6 +39,70 @@ def loaddata(rdb: Redis) -> Redis:
         # Now redis-cli against this
         _ = subprocess.run(["redis-cli", "-p", "6088", "--pipe"], input=data)
     return redis
+
+
+class _FakeSubject:
+    """A dynamically-controllable fake federation subject.
+
+    Listens on a loopback HTTP port and serves whatever JWT body has been
+    registered via `set_entity_configuration()`. Used to test /resolve
+    trust-mark behaviour: the resolver fetches `<entity_id>/.well-known/openid-federation`
+    and we control the response.
+    """
+
+    def __init__(self, port: int, server: http.server.HTTPServer):
+        self.port = port
+        self.entity_id = f"http://127.0.0.1:{port}"
+        self._server = server
+        self._body: bytes | None = None
+
+    def set_entity_configuration(self, jwt_body: str) -> None:
+        self._server.entity_config = jwt_body.encode()  # type: ignore[attr-defined]
+
+    def shutdown(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+
+
+class _SubjectHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 — required by stdlib API
+        if self.path == "/.well-known/openid-federation":
+            body = getattr(self.server, "entity_config", None)
+            if not body:
+                self.send_response(503)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/entity-statement+jwt")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, *_):  # silence stderr spam
+        return
+
+
+@pytest.fixture(scope="function")
+def fake_subject():
+    """A loopback HTTP server that the TA can `GET` as a federation subject.
+
+    Binds to port 0 and reads back the OS-assigned port from `server_address`
+    after bind — no race window between port discovery and listener creation.
+    """
+    server = http.server.HTTPServer(("127.0.0.1", 0), _SubjectHandler)
+    port = server.server_address[1]
+    server.entity_config = None  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    fs = _FakeSubject(port, server)
+    try:
+        yield fs
+    finally:
+        fs.shutdown()
+        thread.join(timeout=2)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,6 @@ class _FakeSubject:
         self.port = port
         self.entity_id = f"http://127.0.0.1:{port}"
         self._server = server
-        self._body: bytes | None = None
 
     def set_entity_configuration(self, jwt_body: str) -> None:
         self._server.entity_config = jwt_body.encode()  # type: ignore[attr-defined]

--- a/tests/test_inmor.py
+++ b/tests/test_inmor.py
@@ -1,12 +1,195 @@
+import base64
 import hashlib
 import json
 import os
+import time
 
 from httpx import Client
-from jwcrypto import jwt
+from jwcrypto import jwk, jwt
 from redis.client import Redis
 
 file_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+# Helpers for the trust-mark-in-resolve tests below.
+#
+# Each test starts from the same loaded Redis dump and may need to rewrite the
+# TA's `trust_mark_issuers` claim. The TA's entity configuration JWT lives at
+# Redis key `inmor:entity_id` and is served verbatim via
+# /.well-known/openid-federation. Because `resolve_entity_to_trustanchor`
+# self-verifies the TA's entity configuration during chain validation, we
+# must re-sign the JWT after editing the payload — see `_repatch_ta_ec()`.
+# The TA's resolve trust-mark gate intentionally trusts Redis (uses
+# `get_unverified_payload_header`) so the re-signed JWT just needs to be
+# decodable; the signature is checked by chain validation which uses the
+# inline `jwks` claim.
+
+_TM_TYPE = "https://sunet.se/does_not_exist_trustmark"
+_TA_ENTITY_ID = "https://localhost:8080"
+_PRIVATE_KEY_PATH = os.path.join(os.path.dirname(file_dir), "private.json")
+
+
+def _b64url_decode(data: str) -> bytes:
+    return base64.urlsafe_b64decode(data + "=" * (-len(data) % 4))
+
+
+def _decode_jwt_payload(jwt_str: str) -> dict:
+    return json.loads(_b64url_decode(jwt_str.split(".")[1]).decode())
+
+
+def _decode_jwt_header(jwt_str: str) -> dict:
+    return json.loads(_b64url_decode(jwt_str.split(".")[0]).decode())
+
+
+def _ta_signing_key() -> jwk.JWK:
+    with open(_PRIVATE_KEY_PATH) as f:
+        key_dict = json.load(f)
+    return jwk.JWK(**key_dict)
+
+
+def _resign_payload(payload: dict, original_header: dict) -> str:
+    """Sign `payload` with the TA's signing key, preserving header `kid`/`typ`."""
+    key = _ta_signing_key()
+    header = {
+        "alg": "RS256",
+        "kid": key.thumbprint() if key.kid is None else key.kid,
+        "typ": original_header.get("typ", "entity-statement+jwt"),
+    }
+    token = jwt.JWT(header=header, claims=payload)
+    token.make_signed_token(key)
+    return token.serialize()
+
+
+def _repatch_ta_ec(rdb: Redis, **payload_changes):
+    """Mutate the TA's entity-config payload and re-sign so chain verification
+    still succeeds.
+
+    Pass `trust_mark_issuers=None` to drop the claim.
+    """
+    raw = rdb.get("inmor:entity_id")
+    jwt_str = raw.decode() if isinstance(raw, bytes) else raw
+    payload = _decode_jwt_payload(jwt_str)
+    header = _decode_jwt_header(jwt_str)
+    for k, v in payload_changes.items():
+        if v is None:
+            payload.pop(k, None)
+        else:
+            payload[k] = v
+    rdb.set("inmor:entity_id", _resign_payload(payload, header))
+
+
+def _set_trust_mark_issuers(rdb: Redis, mapping):
+    """Replace `trust_mark_issuers` in the TA's entity configuration. Pass
+    `None` to drop the claim entirely."""
+    _repatch_ta_ec(rdb, trust_mark_issuers=mapping)
+
+
+def _accept_trust_mark(rdb: Redis, sub: str, trust_mark_obj: dict) -> None:
+    """Make a trust mark eligible for the TA-issued verification path."""
+    jwt_str = trust_mark_obj["trust_mark"]
+    h = hashlib.sha256(jwt_str.encode()).hexdigest()
+    rdb.sadd("inmor:tm:alltime", h)
+    rdb.hset(
+        f"inmor:tm:{sub}",
+        trust_mark_obj["trust_mark_type"],
+        jwt_str,
+    )
+
+
+def _resolve_payload(http_client: Client, port: int, sub: str) -> dict:
+    url = (
+        f"https://localhost:{port}/resolve"
+        f"?sub={sub}&trust_anchor={_TA_ENTITY_ID}"
+    )
+    resp = http_client.get(url)
+    assert resp.status_code == 200, resp.text
+    return _decode_jwt_payload(resp.text)
+
+
+def _sign_with_ta(payload: dict, typ: str) -> str:
+    key = _ta_signing_key()
+    header = {"alg": "RS256", "kid": key.kid, "typ": typ}
+    token = jwt.JWT(header=header, claims=payload)
+    token.make_signed_token(key)
+    return token.serialize()
+
+
+def _build_subject(
+    rdb: Redis,
+    fake_subject,
+    trust_marks: list[dict] | None,
+) -> str:
+    """Spin up a fake subject EC reachable by the TA, register a subordinate
+    statement for it in Redis, and return the subject's entity_id.
+
+    The subject signs its EC with a fresh ephemeral RSA key; the TA verifies
+    the subordinate statement using the inline `jwks` claim (which carries
+    that key). Trust marks (if any) are signed by the TA and embedded in the
+    subject's EC.
+    """
+    subject_id = fake_subject.entity_id
+    subject_key = jwk.JWK.generate(kty="RSA", size=2048, alg="RS256", use="sig")
+    subject_key.kid = subject_key.thumbprint()
+    subject_jwks = {"keys": [json.loads(subject_key.export(private_key=False))]}
+    now = int(time.time())
+    exp = now + 3600
+
+    subject_ec_payload: dict = {
+        "iss": subject_id,
+        "sub": subject_id,
+        "iat": now,
+        "exp": exp,
+        "authority_hints": [_TA_ENTITY_ID],
+        "jwks": subject_jwks,
+        "metadata": {
+            "federation_entity": {"organization_name": "Fake Test Subject"},
+        },
+    }
+    if trust_marks is not None:
+        subject_ec_payload["trust_marks"] = trust_marks
+
+    subject_header = {"alg": "RS256", "kid": subject_key.kid, "typ": "entity-statement+jwt"}
+    subject_ec_token = jwt.JWT(header=subject_header, claims=subject_ec_payload)
+    subject_ec_token.make_signed_token(subject_key)
+    fake_subject.set_entity_configuration(subject_ec_token.serialize())
+
+    # Register a subordinate statement for this subject in the TA. The TA's
+    # /fetch endpoint reads `inmor:subordinates:jwt`. The statement asserts
+    # the subject's keyset and is signed by the TA.
+    sub_statement = _sign_with_ta(
+        {
+            "iss": _TA_ENTITY_ID,
+            "sub": subject_id,
+            "iat": now,
+            "exp": exp,
+            "jwks": subject_jwks,
+        },
+        "entity-statement+jwt",
+    )
+    # The /fetch endpoint reads `inmor:subordinates` (the signed sub statement);
+    # `inmor:subordinates:jwt` is a separate hash used by /list (subject's own EC).
+    rdb.hset("inmor:subordinates", subject_id, sub_statement)
+
+    return subject_id
+
+
+def _build_trust_mark(
+    sub: str,
+    trust_mark_type: str = _TM_TYPE,
+    issuer: str = _TA_ENTITY_ID,
+    exp_offset: int = 3600,
+) -> dict:
+    """Sign a trust mark with the TA's key. Returns the {trust_mark, trust_mark_type} object."""
+    now = int(time.time())
+    payload = {
+        "iss": issuer,
+        "sub": sub,
+        "iat": now,
+        "exp": now + exp_offset,
+        "trust_mark_type": trust_mark_type,
+    }
+    jwt_str = _sign_with_ta(payload, "trust-mark+jwt")
+    return {"trust_mark": jwt_str, "trust_mark_type": trust_mark_type}
 
 
 def test_server(loaddata: Redis, start_server: int, http_client: Client):
@@ -615,3 +798,261 @@ def test_resolve_timeout_on_unreachable(loaddata: Redis, start_server: int, http
         timeout=30,
     )
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /resolve trust mark verification (spec §8.3, §8.3.2)
+# ---------------------------------------------------------------------------
+#
+# These tests exercise verify_trust_marks_for_resolve in src/lib.rs. Each test
+# spins up a `fake_subject` HTTP server on a loopback port, configures it to
+# return a custom entity configuration (built fresh, signed with an ephemeral
+# subject key, with TA-signed trust marks embedded), registers a subordinate
+# statement for the subject in Redis, and resolves it. The TA's allow_http
+# test config lets the resolver fetch http://127.0.0.1:PORT/.well-known/...
+#
+# Trust marks are signed with the TA's own private key (loaded from
+# private.json) so the TA-issued verification path
+# (verify_ta_issued_trust_mark in lib.rs) verifies them against the TA's
+# in-memory public keyset.
+
+
+def test_resolve_includes_ta_issued_trust_mark(
+    loaddata: Redis, start_server: int, http_client: Client, fake_subject
+):
+    "Active TA-issued trust mark must appear in /resolve response (spec §8.3)."
+    rdb = loaddata
+    port = start_server
+
+    subject_id = fake_subject.entity_id
+    tm_obj = _build_trust_mark(subject_id)
+    _build_subject(rdb, fake_subject, trust_marks=[tm_obj])
+    _set_trust_mark_issuers(rdb, {_TM_TYPE: [_TA_ENTITY_ID]})
+    _accept_trust_mark(rdb, subject_id, tm_obj)
+
+    payload = _resolve_payload(http_client, port, subject_id)
+    marks = payload.get("trust_marks")
+    assert marks is not None and len(marks) == 1
+    assert marks[0]["trust_mark_type"] == _TM_TYPE
+    assert marks[0]["trust_mark"] == tm_obj["trust_mark"]
+
+
+def test_resolve_excludes_revoked_ta_issued_trust_mark(
+    loaddata: Redis, start_server: int, http_client: Client, fake_subject
+):
+    "A revoked TA-issued trust mark must not appear in /resolve response."
+    rdb = loaddata
+    port = start_server
+
+    subject_id = fake_subject.entity_id
+    tm_obj = _build_trust_mark(subject_id)
+    _build_subject(rdb, fake_subject, trust_marks=[tm_obj])
+    _set_trust_mark_issuers(rdb, {_TM_TYPE: [_TA_ENTITY_ID]})
+    _accept_trust_mark(rdb, subject_id, tm_obj)
+    rdb.hset(f"inmor:tm:{subject_id}", _TM_TYPE, "revoked")
+
+    payload = _resolve_payload(http_client, port, subject_id)
+    assert "trust_marks" not in payload
+
+
+def test_resolve_excludes_unrecognized_trust_mark_type(
+    loaddata: Redis, start_server: int, http_client: Client, fake_subject
+):
+    "Trust marks whose type is not in trust_mark_issuers must be excluded."
+    rdb = loaddata
+    port = start_server
+
+    subject_id = fake_subject.entity_id
+    tm_obj = _build_trust_mark(subject_id)  # uses _TM_TYPE
+    _build_subject(rdb, fake_subject, trust_marks=[tm_obj])
+    # Restrict the federation to a different type — the subject's mark is unrecognised.
+    _set_trust_mark_issuers(rdb, {"https://example.com/some_other_type": []})
+    _accept_trust_mark(rdb, subject_id, tm_obj)
+
+    payload = _resolve_payload(http_client, port, subject_id)
+    assert "trust_marks" not in payload
+
+
+def test_resolve_excludes_trust_mark_from_disallowed_issuer(
+    loaddata: Redis, start_server: int, http_client: Client, fake_subject
+):
+    "Trust mark whose `iss` is not in the allowed list for its type must be excluded."
+    rdb = loaddata
+    port = start_server
+
+    subject_id = fake_subject.entity_id
+    tm_obj = _build_trust_mark(subject_id)  # iss=_TA_ENTITY_ID
+    _build_subject(rdb, fake_subject, trust_marks=[tm_obj])
+    # Allowed list for the type contains a different issuer — TA's iss must not pass.
+    _set_trust_mark_issuers(rdb, {_TM_TYPE: ["https://other-issuer.example.com"]})
+    _accept_trust_mark(rdb, subject_id, tm_obj)
+
+    payload = _resolve_payload(http_client, port, subject_id)
+    assert "trust_marks" not in payload
+
+
+def test_resolve_includes_trust_mark_when_issuer_list_empty(
+    loaddata: Redis, start_server: int, http_client: Client, fake_subject
+):
+    "Empty allowed-issuer list means anyone may issue (spec §3.1.2)."
+    rdb = loaddata
+    port = start_server
+
+    subject_id = fake_subject.entity_id
+    tm_obj = _build_trust_mark(subject_id)
+    _build_subject(rdb, fake_subject, trust_marks=[tm_obj])
+    _set_trust_mark_issuers(rdb, {_TM_TYPE: []})
+    _accept_trust_mark(rdb, subject_id, tm_obj)
+
+    payload = _resolve_payload(http_client, port, subject_id)
+    marks = payload.get("trust_marks")
+    assert marks is not None and len(marks) == 1
+    assert marks[0]["trust_mark_type"] == _TM_TYPE
+
+
+def test_resolve_omits_trust_marks_claim_when_no_trust_mark_issuers(
+    loaddata: Redis, start_server: int, http_client: Client, fake_subject
+):
+    "If the TA's entity config has no trust_mark_issuers claim, no marks are recognised."
+    rdb = loaddata
+    port = start_server
+
+    subject_id = fake_subject.entity_id
+    tm_obj = _build_trust_mark(subject_id)
+    _build_subject(rdb, fake_subject, trust_marks=[tm_obj])
+    _set_trust_mark_issuers(rdb, None)
+    _accept_trust_mark(rdb, subject_id, tm_obj)
+
+    payload = _resolve_payload(http_client, port, subject_id)
+    assert "trust_marks" not in payload
+
+
+def test_resolve_exp_is_min_of_chain_and_trust_marks(
+    loaddata: Redis, start_server: int, http_client: Client, fake_subject
+):
+    "Per spec §8.3.2, response exp = min(chain exp, trust mark exp)."
+    rdb = loaddata
+    port = start_server
+
+    subject_id = fake_subject.entity_id
+    # Trust mark expires soon (5 minutes); chain entries are typically longer.
+    tm_obj = _build_trust_mark(subject_id, exp_offset=300)
+    _build_subject(rdb, fake_subject, trust_marks=[tm_obj])
+    _set_trust_mark_issuers(rdb, {_TM_TYPE: [_TA_ENTITY_ID]})
+    _accept_trust_mark(rdb, subject_id, tm_obj)
+
+    payload = _resolve_payload(http_client, port, subject_id)
+    marks = payload.get("trust_marks")
+    assert marks is not None and len(marks) == 1, "trust mark must be included"
+
+    tm_exp = int(_decode_jwt_payload(tm_obj["trust_mark"])["exp"])
+    chain_exps = []
+    for entry in payload.get("trust_chain", []):
+        chain_payload = _decode_jwt_payload(entry)
+        if "exp" in chain_payload:
+            chain_exps.append(int(chain_payload["exp"]))
+    assert chain_exps, "trust chain must have at least one exp"
+
+    expected_min = min(min(chain_exps), tm_exp)
+    response_exp = int(payload["exp"])
+    assert response_exp <= expected_min, (
+        f"response exp {response_exp} must be <= min(chain exp {min(chain_exps)}, "
+        f"trust mark exp {tm_exp}) = {expected_min}"
+    )
+
+
+def test_resolve_excludes_unknown_trust_mark(
+    loaddata: Redis, start_server: int, http_client: Client, fake_subject
+):
+    "A trust mark whose hash is not in inmor:tm:alltime must be excluded."
+    rdb = loaddata
+    port = start_server
+
+    subject_id = fake_subject.entity_id
+    tm_obj = _build_trust_mark(subject_id)
+    _build_subject(rdb, fake_subject, trust_marks=[tm_obj])
+    _set_trust_mark_issuers(rdb, {_TM_TYPE: [_TA_ENTITY_ID]})
+    # Intentionally skip _accept_trust_mark — the SISMEMBER check fails.
+
+    payload = _resolve_payload(http_client, port, subject_id)
+    assert "trust_marks" not in payload
+
+
+def test_resolve_caps_trust_marks_at_limit(
+    loaddata: Redis, start_server: int, http_client: Client, fake_subject
+):
+    "Subject EC with more marks than MAX_TRUST_MARKS_PER_RESOLVE must be capped."
+    rdb = loaddata
+    port = start_server
+
+    subject_id = fake_subject.entity_id
+
+    # 50 valid TA-issued marks (well over the 32 cap).
+    marks = [_build_trust_mark(subject_id) for _ in range(50)]
+    _build_subject(rdb, fake_subject, trust_marks=marks)
+    _set_trust_mark_issuers(rdb, {_TM_TYPE: [_TA_ENTITY_ID]})
+    for m in marks:
+        _accept_trust_mark(rdb, subject_id, m)
+
+    payload = _resolve_payload(http_client, port, subject_id)
+    response_marks = payload.get("trust_marks") or []
+    assert len(response_marks) <= 32, (
+        f"response carried {len(response_marks)} marks; resolver must cap at 32"
+    )
+
+
+def test_resolve_rejects_outer_inner_trust_mark_type_mismatch(
+    loaddata: Redis, start_server: int, http_client: Client, fake_subject
+):
+    "Per spec §7.4, outer trust_mark_type MUST equal inner; mismatch → skip."
+    rdb = loaddata
+    port = start_server
+
+    subject_id = fake_subject.entity_id
+
+    # Build a perfectly valid TA-issued mark (inner trust_mark_type=_TM_TYPE).
+    tm_obj = _build_trust_mark(subject_id)
+    # Then lie in the outer wrapper.
+    tampered = {
+        "trust_mark": tm_obj["trust_mark"],
+        "trust_mark_type": "https://example.com/some_other_type",
+    }
+    _build_subject(rdb, fake_subject, trust_marks=[tampered])
+    # Recognise BOTH types so the mismatch (not the recognition gate) is what skips it.
+    _set_trust_mark_issuers(
+        rdb,
+        {
+            _TM_TYPE: [_TA_ENTITY_ID],
+            "https://example.com/some_other_type": [_TA_ENTITY_ID],
+        },
+    )
+    _accept_trust_mark(rdb, subject_id, tm_obj)
+
+    payload = _resolve_payload(http_client, port, subject_id)
+    assert "trust_marks" not in payload, (
+        "outer/inner trust_mark_type mismatch must be rejected (spec §7.4)"
+    )
+
+
+def test_resolve_rejects_trust_mark_for_different_subject(
+    loaddata: Redis, start_server: int, http_client: Client, fake_subject
+):
+    "A trust mark whose inner `sub` differs from the resolve subject must be skipped."
+    rdb = loaddata
+    port = start_server
+
+    subject_id = fake_subject.entity_id
+
+    # Build a mark issued to someone else and embed it in our subject's EC.
+    other_entity = "https://other.example.com"
+    foreign_mark = _build_trust_mark(other_entity)
+    _build_subject(rdb, fake_subject, trust_marks=[foreign_mark])
+    _set_trust_mark_issuers(rdb, {_TM_TYPE: [_TA_ENTITY_ID]})
+    # Accept the mark under the *correct* (foreign) subject — so the only
+    # remaining barrier is the sub-mismatch check we're testing.
+    _accept_trust_mark(rdb, other_entity, foreign_mark)
+
+    payload = _resolve_payload(http_client, port, subject_id)
+    assert "trust_marks" not in payload, (
+        "trust mark whose JWT sub doesn't match the resolve subject must not be included"
+    )

--- a/tests/test_inmor.py
+++ b/tests/test_inmor.py
@@ -48,7 +48,12 @@ def _ta_signing_key() -> jwk.JWK:
 
 
 def _resign_payload(payload: dict, original_header: dict) -> str:
-    """Sign `payload` with the TA's signing key, preserving header `kid`/`typ`."""
+    """Sign `payload` with the TA's signing key, preserving the original `typ`.
+
+    The `kid` is taken from the signing key (or its thumbprint if the key has
+    none); we don't carry over `original_header["kid"]` because the signature
+    has to validate against whatever key we're actually signing with.
+    """
     key = _ta_signing_key()
     header = {
         "alg": "RS256",
@@ -154,8 +159,9 @@ def _build_subject(
     fake_subject.set_entity_configuration(subject_ec_token.serialize())
 
     # Register a subordinate statement for this subject in the TA. The TA's
-    # /fetch endpoint reads `inmor:subordinates:jwt`. The statement asserts
-    # the subject's keyset and is signed by the TA.
+    # /fetch endpoint reads it via `HGET inmor:subordinates {subject_id}` (see
+    # `fetch_subordinates` in src/lib.rs). The statement asserts the subject's
+    # keyset and is signed by the TA.
     sub_statement = _sign_with_ta(
         {
             "iss": _TA_ENTITY_ID,


### PR DESCRIPTION
Implements OpenID Federation 8.3 trust mark verification in the /resolve endpoint. Previously the trust chain and metadata policies were emitted but trust marks were ignored entirely; 8.3 requires verifying that present marks are active and including only verified marks in the response, and 8.3.2 requires response exp to be the minimum of the trust chain exp and every included trust mark exp.

Rust (src/lib.rs)
-----------------
* New verify_ta_issued_trust_mark(): local Redis + signature path for marks issued by this TA (inmor:tm:alltime hash + verify_jwt_with_jwks
  + revocation lookup in inmor:tm:{sub}).
* New verify_single_trust_mark(): dispatches TA vs external; external fetches the issuer's entity config over the SSRF-gated HTTP client, discovers federation_trust_mark_status_endpoint, POSTs the mark to it, and verifies the response JWT signature against the issuer's JWKS (jwks claim or jwks_uri fallback). Accepts only status="active". Fail-closed at every step with WARN logs.
* New verify_trust_marks_for_resolve(): reads the TA's own entity configuration from Redis (inmor:entity_id, trust boundary identical to /.well-known/openid-federation), applies the trust_mark_issuers recognition gate per 3.1.2 (empty list = any issuer), and returns the verified marks.
* New post_form_query() helper mirroring get_query()'s SSRF gate, shared HTTP_CLIENT, and MAX_RESPONSE_BYTES cap.
* create_resolve_response_jwt() now takes trust_marks; sets the trust_marks claim when non-empty and folds each mark's exp into the min_exp calculation.
* resolve_entity() calls verify_trust_marks_for_resolve after chain validation and passes the result downstream.

Hardening (caught in self-review, applied here)
-----------------------------------------------
* DoS bound: MAX_TRUST_MARKS_PER_RESOLVE=32 cap on marks processed per resolve, plus a 30s tokio::time::timeout wall-clock budget on the whole trust-mark phase. An attacker-controlled subject EC can carry hundreds of marks (up to MAX_RESPONSE_BYTES); without these limits each external mark could chain two 10s HTTP timeouts and stall a worker for minutes.
* Spec 7.4: skip marks whose outer trust_mark_type disagrees with the JWT's inner trust_mark_type claim - prevents split-brain entries in the resolve response and closes a recognition-gate bypass where outer says "type-A" (recognised) but inner says "type-B".

Admin (admin/entities/lib.py)
-----------------------------
* create_server_statement() now auto-includes the TA's own entity_id (settings.TRUSTMARK_PROVIDER, the iss of every mark this admin issues) in trust_mark_issuers for each active TrustMarkType. Operators only need to configure *external* issuers in TA_TRUSTED_TRUSTMARK_ISSUERS.
* Explicit "{type: []}" in settings is preserved as the 3.1.2 "anyone may issue" marker; auto-include is suppressed for those types so the operator's intent isn't silently flipped to "TA only".