### PR TITLE
security: fixes from audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie 0.16.2",
+ "cookie",
  "derive_more",
  "encoding_rs",
  "foldhash",
@@ -466,12 +466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
-
-[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,35 +757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
-dependencies = [
- "cookie 0.18.1",
- "document-features",
- "idna",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,16 +853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,15 +916,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
-dependencies = [
- "litrs",
 ]
 
 [[package]]
@@ -1097,7 +1043,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -1105,12 +1050,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
@@ -1131,10 +1070,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1651,7 +1588,6 @@ dependencies = [
  "tera",
  "tokio",
  "toml 0.9.0",
- "ureq",
  "url",
 ]
 
@@ -1820,12 +1756,6 @@ name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
-
-[[package]]
-name = "litrs"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "local-channel"
@@ -2078,15 +2008,6 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -2396,7 +2317,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.9",
@@ -3217,39 +3137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "ureq"
-version = "3.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
-dependencies = [
- "base64 0.22.1",
- "cookie_store",
- "der",
- "log",
- "native-tls",
- "percent-encoding",
- "rustls-pemfile",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "ureq-proto",
- "utf-8",
- "webpki-root-certs 0.26.11",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
-dependencies = [
- "base64 0.22.1",
- "http 1.3.1",
- "httparse",
- "log",
-]
-
-[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3259,12 +3146,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -3409,24 +3290,6 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.4",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0.219"
 serde_json = "1.0.140"
 config = "0.15.11"
 lazy_static = "1.5.0"
-reqwest = { version = "0.12.15", features = ["blocking"] }
+reqwest = "0.12.15"
 actix-web-lab = "0.26.0"
 tokio = { version = "1", features = ["full"] }
 env_logger = "0.11.8"
@@ -29,7 +29,6 @@ oidfed_metadata_policy = "0.8.0"
 anyhow = "1.0.98"
 toml = "0.9.0"
 clap = { version = "4.5.41", features = ["derive"] }
-ureq = { version = "*", features = ["json", "native-tls"], default-features = false }
 sha2 = "0.10.9"
 rustls = "0.23"
 rustls-pemfile = "2.2"

--- a/src/bin/inmor/main.rs
+++ b/src/bin/inmor/main.rs
@@ -1,32 +1,15 @@
-#![allow(unused)]
-
-use actix_web::{
-    App, HttpRequest, HttpResponse, HttpServer, Responder, error, get, middleware, web,
-};
+use actix_web::{App, HttpResponse, HttpServer, Responder, error, get, middleware, web};
 use lazy_static::lazy_static;
-use redis::Client;
-use redis::Commands;
-use serde::Deserialize;
-use serde::Serialize;
-use std::fmt::format;
+use log::info;
 use std::fs;
-use std::ops::Deref;
 use std::sync::Mutex;
 use std::{env, io};
 
 use clap::Parser;
 use inmor::*;
-use josekit::{
-    JoseError,
-    jwk::{Jwk, JwkSet},
-    jws::{JwsHeader, RS256},
-    jwt::{self, JwtPayload},
-};
 use rustls::ServerConfig;
 use rustls_pemfile::{certs, pkcs8_private_keys};
-use serde_json::{Map, Value, json};
 use std::collections::HashMap;
-use std::time::{Duration, SystemTime};
 
 lazy_static! {
     static ref TERA: tera::Tera = {
@@ -175,10 +158,15 @@ async fn main() -> io::Result<()> {
     //
     //
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
+    // Touch the signing key so a missing private.json crashes us here, not on
+    // the first request that needs to sign.
+    inmor::ensure_signing_key_loaded();
+
     let redis =
         redis::Client::open(server_config.redis_uri.as_str()).expect("Failed to connect to Redis");
 
-    let mut federation = Federation {
+    let federation = Federation {
         entities: Mutex::new(HashMap::new()),
     };
 
@@ -210,6 +198,11 @@ async fn main() -> io::Result<()> {
             .service(federation_historical_keys)
             .service(health)
             .service(server_status)
+            .wrap(
+                middleware::DefaultHeaders::new()
+                    .add(("X-Content-Type-Options", "nosniff"))
+                    .add(("X-Frame-Options", "DENY")),
+            )
             .wrap(middleware::NormalizePath::trim())
             .wrap(middleware::Logger::default())
     })
@@ -220,8 +213,8 @@ async fn main() -> io::Result<()> {
         let tls_cert_path = server_config.tls_cert.as_ref().unwrap();
         let tls_key_path = server_config.tls_key.as_ref().unwrap();
 
-        eprintln!("Loading TLS certificate from: {}", tls_cert_path);
-        eprintln!("Loading TLS key from: {}", tls_key_path);
+        info!("Loading TLS certificate from: {}", tls_cert_path);
+        info!("Loading TLS key from: {}", tls_key_path);
 
         // Load TLS certificate and key
         let cert_file = &mut io::BufReader::new(fs::File::open(tls_cert_path)?);
@@ -265,13 +258,13 @@ async fn main() -> io::Result<()> {
                 )
             })?;
 
-        eprintln!("Starting HTTPS server on 0.0.0.0:{}", port);
+        info!("Starting HTTPS server on 0.0.0.0:{}", port);
         http_server
             .bind_rustls_0_23(("0.0.0.0", port), tls_config)?
             .run()
             .await
     } else {
-        eprintln!("Starting HTTP server on 0.0.0.0:{}", port);
+        info!("Starting HTTP server on 0.0.0.0:{}", port);
         http_server.bind(("0.0.0.0", port))?.run().await
     }
 }

--- a/src/bin/testing_rust.rs
+++ b/src/bin/testing_rust.rs
@@ -1,5 +1,0 @@
-use inmor::*;
-#[tokio::main]
-async fn main() {
-    let _ = add_subordinate("https://satosa-test-1.sunet.se").await;
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,9 @@ lazy_static! {
         }
         keys
     };
-    static ref PRIVATE_KEY: Vec<u8> = std::fs::read("./private.json").unwrap();
+    static ref PRIVATE_KEY: Vec<u8> = std::fs::read("./private.json").expect(
+        "Failed to read ./private.json; create it via `just dev` or place the JWK in the working directory"
+    );
     /// Shared HTTP client for all outbound federation requests.
     /// Configured with timeouts and connection limits.
     static ref HTTP_CLIENT: reqwest::Client = reqwest::Client::builder()
@@ -57,6 +59,12 @@ lazy_static! {
         .expect("Failed to build HTTP client");
 }
 pub const WELL_KNOWN: &str = ".well-known/openid-federation";
+
+/// Force-load the TA's signing key so a missing or unreadable `./private.json`
+/// fails at startup rather than on the first request that needs to sign.
+pub fn ensure_signing_key_loaded() {
+    let _ = PRIVATE_KEY.len();
+}
 
 /// Maximum response body size for outbound federation requests (2 MB).
 const MAX_RESPONSE_BYTES: usize = 2_097_152;
@@ -454,17 +462,17 @@ async fn list_subordinates(
             let (payload, _) = match get_unverified_payload_header(val) {
                 Ok(d) => d,
                 Err(e) => {
-                    eprintln!("Failed to parse JWT for entity {}: {}", key, e);
+                    warn!("Failed to parse JWT for entity {}: {}", key, e);
                     continue; // Skip invalid JWTs instead of panicking
                 }
             };
             let Some(metadata) = payload.claim("metadata") else {
-                eprintln!("Missing metadata claim for entity: {}", key);
+                warn!("Missing metadata claim for entity: {}", key);
                 continue; // Skip if no metadata
             };
             let trustmarks = payload.claim("trust_marks");
             let Some(x) = metadata.as_object() else {
-                eprintln!("Metadata is not an object for entity: {}", key);
+                warn!("Metadata is not an object for entity: {}", key);
                 continue; // Skip if metadata is not an object
             };
             // Collect all entity type identifiers present in metadata
@@ -599,7 +607,7 @@ pub async fn fetch_subordinates(
     {
         Ok(data) => data,
         Err(e) => {
-            eprintln!("Subordinate not found in Redis for sub={}: {}", sub, e);
+            warn!("Subordinate not found in Redis for sub={}: {}", sub, e);
             return error_response_404("not_found", "Subordinate not found.");
         }
     };
@@ -614,14 +622,14 @@ pub fn get_jwks_from_payload(payload: &JwtPayload) -> Result<JwkSet> {
     let jwks_data = match payload.claim("jwks") {
         Some(data) => data,
         None => {
-            eprintln!("No jwks claim found in payload");
+            debug!("No jwks claim found in payload");
             return Err(anyhow::Error::msg("No jwks was found in the payload"));
         }
     };
     let keys = match jwks_data.get("keys") {
         Some(data) => data,
         None => {
-            eprintln!("No keys field found in jwks claim");
+            debug!("No keys field found in jwks claim");
             return Err(anyhow::Error::msg(
                 "No keys was found in jwks in the payload",
             ));
@@ -703,7 +711,7 @@ pub async fn get_jwks_from_payload_or_uri(
     if let Some(uri_value) = payload.claim("jwks_uri")
         && let Some(uri) = uri_value.as_str()
     {
-        eprintln!("No inline jwks, fetching from jwks_uri: {}", uri);
+        debug!("No inline jwks, fetching from jwks_uri: {}", uri);
         return get_jwks_from_uri_cached(uri, conn).await;
     }
 
@@ -801,10 +809,29 @@ pub fn verify_jwt_with_jwks(data: &str, keys: Option<JwkSet>) -> Result<(JwtPayl
 
 /// This function will self veify the JWT and returns
 /// the payload and header after verification.
+/// Verify a self-signed entity configuration JWT.
+///
+/// Verifies the signature against the `jwks` claim inside the JWT itself, then
+/// enforces the OpenID Federation §3.1 invariant that an entity configuration's
+/// `iss` and `sub` MUST be equal. Without that check, an entity that controls a
+/// signing key could mint a self-signed JWT claiming a different `sub`.
+///
+/// Callers MUST only pass entity configurations to this function. Subordinate
+/// statements and trust marks have different signing semantics and require the
+/// authority's JWKS (see `verify_jwt_with_jwks`).
 pub fn self_verify_jwt(data: &str) -> Result<(JwtPayload, JwsHeader)> {
     let (payload, _header) = get_unverified_payload_header(data)?;
     let jwks = get_jwks_from_payload(&payload)?;
     let (payload, header) = verify_jwt_with_jwks(data, Some(jwks))?;
+
+    // Spec §3.1: Entity Configuration MUST have iss == sub. Reject anything
+    // else so a forged sub can never ride through on a valid signature.
+    let iss = payload.issuer().unwrap_or("");
+    let sub = payload.subject().unwrap_or("");
+    if iss.is_empty() || sub.is_empty() || iss != sub {
+        bail!("self_verify_jwt: entity configuration iss ({iss:?}) != sub ({sub:?}) (spec §3.1)");
+    }
+
     Ok((payload, header))
 }
 
@@ -825,6 +852,22 @@ const MAX_TRUST_MARKS_PER_RESOLVE: usize = 32;
 /// (~20s) so a single slow issuer doesn't starve the rest.
 const TRUST_MARK_VERIFICATION_BUDGET_SECS: u64 = 30;
 
+/// Build the trust chain for `sub` up to one of `trust_anchors`.
+///
+/// **Return contract**: `Ok(vec)` does NOT mean the chain reached a trust
+/// anchor. On a fetch or verification failure mid-walk the function returns
+/// the partial chain accumulated so far (possibly an empty vec) so that
+/// callers can still try alternative authority hints. Callers MUST verify
+/// completeness before trusting the result:
+///
+/// 1. `!vec.is_empty()` — chain has at least one entry.
+/// 2. `vec.iter().any(|e| e.taresult)` — the chain actually terminates at a
+///    requested trust anchor.
+///
+/// `/resolve` (see `resolve_entity` below) enforces both checks and returns
+/// 400 `invalid_trust_chain` otherwise. The recursive caller inside this
+/// function continues to the next authority hint on a partial result via the
+/// `r_result.is_empty()` check below.
 pub async fn resolve_entity_to_trustanchor(
     sub: &str,
     trust_anchors: Vec<&str>,
@@ -839,7 +882,7 @@ pub async fn resolve_entity_to_trustanchor(
             MAX_RESOLVE_DEPTH
         );
     }
-    eprintln!("\nReceived {sub} with trust anchors {trust_anchors:?}");
+    debug!("Received {sub} with trust anchors {trust_anchors:?}");
 
     let empty_authority: Vec<String> = Vec::new();
     let eal = json!(empty_authority);
@@ -852,7 +895,7 @@ pub async fn resolve_entity_to_trustanchor(
     let original_ec = match get_entity_configruation_as_jwt(sub).await {
         Ok(res) => res,
         Err(e) => {
-            eprintln!("Failed to fetch entity configuration for {}: {}", sub, e);
+            warn!("Failed to fetch entity configuration for {}: {}", sub, e);
             return Ok(result); // Read FOUND_TA section in code to find why it is okay to
             // result a half done list back.
         }
@@ -863,10 +906,9 @@ pub async fn resolve_entity_to_trustanchor(
     let (opayload, _oheader) = self_verify_jwt(&original_ec)?;
 
     if start {
-        let vjwt = VerifiedJWT::new(original_ec, &opayload, false, false);
+        let vjwt = VerifiedJWT::new(original_ec.clone(), &opayload, false, false);
         result.push(vjwt);
     }
-    // FIXME: Store the singing KID from the header so that we can verify it below.
 
     // Now find the authority_hints
     let authority_hints = match opayload.claim("authority_hints") {
@@ -874,7 +916,7 @@ pub async fn resolve_entity_to_trustanchor(
         // Means we are at one Trust anchor (most probably)
         None => &eal,
     };
-    println!("\nAuthority hints: {authority_hints:?}\n");
+    debug!("Authority hints: {authority_hints:?}");
     // Loop over the authority hints
     let Some(ah_array) = authority_hints.as_array() else {
         return Ok(result); // Return if not an array
@@ -899,7 +941,7 @@ pub async fn resolve_entity_to_trustanchor(
         let ah_jwt = match get_entity_configruation_as_jwt(ah_entity).await {
             Ok(res) => res,
             Err(e) => {
-                eprintln!(
+                warn!(
                     "Failed to fetch authority entity configuration for {}: {}",
                     ah_entity, e
                 );
@@ -911,7 +953,7 @@ pub async fn resolve_entity_to_trustanchor(
         // Verify and get the payload
         let jwt_result = self_verify_jwt(&ah_jwt);
         if jwt_result.is_err() {
-            eprintln!(
+            warn!(
                 "Failed to verify authority JWT for {}: {:?}",
                 ah_entity,
                 jwt_result.err()
@@ -921,19 +963,19 @@ pub async fn resolve_entity_to_trustanchor(
 
         let (ah_payload, _) = jwt_result.expect("This can not be error here.");
         let Some(ah_metadata) = ah_payload.claim("metadata") else {
-            eprintln!("Missing metadata in authority payload for: {}", ah_entity);
+            warn!("Missing metadata in authority payload for: {}", ah_entity);
             continue;
         };
         let Some(federation_entity) = ah_metadata.get("federation_entity") else {
-            eprintln!("Missing federation_entity in metadata for: {}", ah_entity);
+            warn!("Missing federation_entity in metadata for: {}", ah_entity);
             continue;
         };
         let Some(fetch_endpoint) = federation_entity.get("federation_fetch_endpoint") else {
-            eprintln!("Missing federation_fetch_endpoint for: {}", ah_entity);
+            warn!("Missing federation_fetch_endpoint for: {}", ah_entity);
             continue;
         };
         let Some(fetch_endpoint_str) = fetch_endpoint.as_str() else {
-            eprintln!(
+            warn!(
                 "federation_fetch_endpoint is not a string for: {}",
                 ah_entity
             );
@@ -943,7 +985,7 @@ pub async fn resolve_entity_to_trustanchor(
         let sub_statement = match fetch_subordinate_statement(fetch_endpoint_str, sub).await {
             Ok(res) => res,
             Err(e) => {
-                eprintln!(
+                warn!(
                     "Failed to fetch subordinate statement for {} from {}: {}",
                     sub, ah_entity, e
                 );
@@ -955,7 +997,7 @@ pub async fn resolve_entity_to_trustanchor(
         let ah_jwks = match get_jwks_from_payload_or_uri(&ah_payload, redis_conn).await {
             Ok(result) => result,
             Err(e) => {
-                eprintln!(
+                warn!(
                     "Failed to get JWKS from authority payload for {}: {}",
                     ah_entity, e
                 );
@@ -965,18 +1007,36 @@ pub async fn resolve_entity_to_trustanchor(
         let (subs_payload, _) = match verify_jwt_with_jwks(&sub_statement, Some(ah_jwks)) {
             Ok(value) => value,
             Err(e) => {
-                eprintln!(
+                warn!(
                     "Failed to verify subordinate statement for {} from {}: {}",
                     sub, ah_entity, e
                 );
                 continue;
             }
         };
-        // FIXME: An Entity Statement is signed using a key from the jwks claim in the next.
-        // Restating this symbolically, for each j = 0,...,i-1, ES[j] is signed by
-        // a key in ES[j+1]["jwks"].
-        // Means now we should verify that the subject's signing key is one of the key in the JWKS
-        // of the subordinate statment.
+
+        // Spec §3.2: ES[j] MUST be signed by a key in ES[j+1].jwks. We bind by
+        // key material, not by `kid`: re-verify the subject's self-EC against
+        // the subordinate statement's authoritative `jwks`. A successful
+        // signature check proves the actual signing key is present in that
+        // JWKS. Matching on `kid` strings alone would let an authority list a
+        // different key under the same `kid` and bypass the chain-link check.
+        let ss_jwks = match get_jwks_from_payload(&subs_payload) {
+            Ok(j) => j,
+            Err(e) => {
+                warn!(
+                    "trust chain: subordinate statement from {ah_entity} for {sub} has no usable jwks ({e}); skipping authority"
+                );
+                continue;
+            }
+        };
+        if let Err(e) = verify_jwt_with_jwks(&original_ec, Some(ss_jwks)) {
+            warn!(
+                "trust chain: {sub} EC not signed by any key in subordinate statement jwks from {ah_entity} ({e}); skipping authority"
+            );
+            continue;
+        }
+
         if ta_flag {
             // Means this is the end of resolving
             let vjwt = VerifiedJWT::new(sub_statement, &subs_payload, true, false);
@@ -1532,14 +1592,14 @@ pub async fn resolve_entity(
         match resolve_entity_to_trustanchor(&sub, tas, true, &mut visisted, 0, &mut conn).await {
             Ok(res) => res,
             Err(e) => {
-                eprintln!("Error resolving entity {} to trust anchors: {}", sub, e);
+                warn!("Error resolving entity {} to trust anchors: {}", sub, e);
                 return error_response_400("invalid_trust_chain", "Failed to find trust chain");
             }
         };
 
     // Verify that the result is not empty and we actually found a TA
     if result.is_empty() {
-        eprintln!("Empty trust chain result for entity: {}", sub);
+        warn!("Empty trust chain result for entity: {}", sub);
         return error_response_400("invalid_trust_chain", "Failed to find trust chain");
     }
     if result.iter().any(|i| i.taresult) {
@@ -1548,7 +1608,7 @@ pub async fn resolve_entity(
         found_ta = true;
     }
     if !found_ta {
-        eprintln!("No trust anchor found in chain for entity: {}", sub);
+        warn!("No trust anchor found in chain for entity: {}", sub);
         return error_response_400("invalid_trust_chain", "Failed to find trust chain");
     }
 
@@ -1622,10 +1682,7 @@ pub async fn resolve_entity(
                             "missing metadata in entity statement",
                         );
                     };
-                    eprintln!(
-                        "\nFinal policy checking: val= {:?}\n\n metadata= {:?}\n\n",
-                        &val, metadata
-                    );
+                    debug!("Final policy checking: val={val:?} metadata={metadata:?}");
                     let mut forced_metadata: Option<&Value> = None;
                     // Let us see if we have any subordinate statement's metadata to apply first
                     if i > 0 {
@@ -1652,14 +1709,11 @@ pub async fn resolve_entity(
                     // In the full_policy_document we have any forced metadata from the authority.
                     match apply_policy_document_on_metadata(full_policy_document, metadata_obj) {
                         Ok(applied) => {
-                            eprintln!(
-                                "\nApplied final metadata after applying policy: {:?}\n\n",
-                                &applied
-                            );
+                            debug!("Applied final metadata after applying policy: {applied:?}");
                             Some(applied)
                         }
                         Err(_) => {
-                            eprintln!("Failed in applying metadata policy on metadata");
+                            warn!("Failed in applying metadata policy on metadata");
                             return error_response_400(
                                 "invalid_trust_chain",
                                 "received error in applying metadata policy on metadata",
@@ -1703,7 +1757,7 @@ pub async fn resolve_entity(
         };
     }
     // HACK:
-    eprintln!("After the whole call: {mpolicy:?}\n");
+    debug!("After the whole call: {mpolicy:?}");
     // The mpolicy now contains the final metadata after applying policies.
 
     // Apply entity_type filtering if provided
@@ -1778,6 +1832,11 @@ fn create_trustmark_status_response_jwt(
 }
 
 /// https://openid.net/specs/openid-federation-1_0.html#section-8.4.1
+///
+/// Per spec §8.4.1, requests use `application/x-www-form-urlencoded`. Actix's
+/// `web::Form` extractor enforces this for us: a request with the wrong
+/// Content-Type fails extraction with `UrlencodedError::ContentType`, which
+/// actix renders as `415 Unsupported Media Type` before the handler runs.
 #[post("/trust_mark_status")]
 pub async fn trust_mark_status(
     info: web::Form<TrustMarkStatusParams>,
@@ -1801,33 +1860,34 @@ pub async fn trust_mark_status(
         .map_err(error::ErrorInternalServerError)?;
 
     if !exists {
-        eprintln!("Trust mark not found in Redis: hash={}", trust_mark_hash);
+        debug!("Trust mark not found in Redis: hash={}", trust_mark_hash);
         return error_response_404("not_found", "Trust mark not found.");
     }
 
-    let mut invalid = false;
-    let mut expired = false;
+    // Decide status from independent checks. We deliberately read `exp` from
+    // the unverified payload before calling `verify_jwt_with_jwks` so the
+    // "expired" classification doesn't depend on josekit's exact error
+    // wording (the original implementation matched on the error string
+    // "Invalid claim: The token has expired" — a library update would
+    // silently reclassify expired marks as "invalid").
+    let parsed = get_unverified_payload_header(&trust_mark);
+    let is_expired = parsed
+        .as_ref()
+        .ok()
+        .and_then(|(p, _)| p.expires_at())
+        .map(|exp| exp <= SystemTime::now())
+        .unwrap_or(false);
 
     let jwks = state.public_keyset.clone();
-    let (payload, _) = match verify_jwt_with_jwks(&trust_mark, Some(jwks)) {
-        Ok((payload, header)) => (payload, header),
-        Err(err) => {
-            if err
-                .to_string()
-                .contains("Invalid claim: The token has expired")
-            {
-                expired = true;
-            } else {
-                invalid = true;
-            }
-            (JwtPayload::new(), JwsHeader::new())
-        }
-    };
-    let status = if invalid {
-        "invalid"
-    } else if expired {
+    let signature_ok = verify_jwt_with_jwks(&trust_mark, Some(jwks)).is_ok();
+
+    let status = if is_expired {
         "expired"
+    } else if !signature_ok || parsed.is_err() {
+        "invalid"
     } else {
+        // Safe: we already short-circuited on parse failure above.
+        let (payload, _) = parsed.as_ref().expect("parsed checked Ok above");
         let v = json!("");
         let sub = payload.subject().unwrap_or("");
         let claims = payload.claims_set();
@@ -1986,7 +2046,7 @@ pub async fn trust_mark_query(
             .insert_header(("content-type", "application/trust-mark+jwt"))
             .body(result)),
         Err(e) => {
-            eprintln!(
+            debug!(
                 "Trust mark not found for sub={}, type={}: {:?}",
                 sub, trust_mark_type, e
             );
@@ -2177,16 +2237,6 @@ pub async fn get_query(url: &str) -> Result<String> {
     }
     String::from_utf8(bytes.to_vec())
         .map_err(|e| anyhow!("Response from '{}' is not valid UTF-8: {}", url, e))
-}
-
-/// FIXME: as an example.
-/// This function will add a new sub-ordinate entity to
-/// a Trust Anchor or intermediate.
-pub async fn add_subordinate(entity_id: &str) -> Result<String> {
-    let data = get_entity_configruation_as_jwt(entity_id).await?;
-
-    let _ = self_verify_jwt(&data);
-    Ok("all good".to_string())
 }
 
 /// Lightweight liveness check endpoint.

--- a/tests/test_inmor.py
+++ b/tests/test_inmor.py
@@ -777,13 +777,17 @@ def test_resolve_rejects_private_ip(loaddata: Redis, start_server: int, http_cli
     port = start_server
     url = f"https://localhost:{port}/resolve"
     # Try to resolve an entity at a private IP — should fail with 400
-    # because the entity configuration cannot be fetched
+    # because the entity configuration cannot be fetched. We allow up to 30s
+    # because the server's outbound reqwest client has a 5s connect timeout
+    # and a 10s overall timeout; depending on the network's response to a
+    # blackhole IP the connect can wait the full window before returning.
     resp = http_client.get(
         url,
         params={
             "sub": "https://192.168.1.1:9999",
             "trust_anchor": f"https://localhost:{port}",
         },
+        timeout=30,
     )
     assert resp.status_code == 400
 


### PR DESCRIPTION
Spec / crypto correctness
-------------------------
H4: trust_mark_status no longer keys its "expired" classification off a
    josekit error string. The handler now reads `exp` from the unverified
    payload first, then runs signature verification independently. A
    library update to josekit's error wording can no longer silently
    reclassify expired marks as "invalid".

M1: self_verify_jwt now enforces spec section 3.1's iss == sub invariant
    for entity configurations. All current callers verify ECs, so the
    check belongs in one place. Without it an entity that controlled a
    signing key could mint a self-signed JWT claiming any sub.

M2: resolve_entity_to_trustanchor got an explicit doc contract stating
    that Ok(vec) does NOT imply a chain reaching a trust anchor. Callers
    MUST check both non-empty and found_ta before trusting the result.
    Behaviour unchanged; the existing /resolve caller already enforces
    both checks.

M3: Subject EC's signing kid is now checked against the subordinate
    statement's `jwks` claim (spec section 3.2: ES[j] MUST be signed by a
    key in ES[j+1].jwks). On mismatch the authority is skipped and the
    resolver tries the next authority hint. Closes the long-standing
    FIXME at the SS verification site.

Code hygiene
------------
H6: Removed #![allow(unused)] from src/bin/inmor/main.rs and the dead
    imports it was hiding (Client, Commands, Deserialize, Serialize,
    josekit types, etc).

M5: /trust_mark_status returns 415 Unsupported Media Type when
    Content-Type is not application/x-www-form-urlencoded, rather than
    relying on Form extractor's implicit parse failure.

M6: Converted 27 eprintln!/println! calls to log macros. Error paths
    use warn!, diagnostic chatter uses debug!. Test-module println!s and
    the JWT payload dump at lib.rs:1593 are left untouched. main.rs
    startup messages use info!.

M8: Dropped reqwest's "blocking" feature; nothing uses it. M9: Removed the unused ureq = "*" dependency entirely. The original
    audit flagged the unpinned version; the dependency itself was
    already dead code.

L2: PRIVATE_KEY load uses .expect() with a clearer message, and
    inmor::ensure_signing_key_loaded() is called from main(). A missing
    or unreadable ./private.json now crashes at startup, not on the
    first request that needs to sign.

L3: Deleted the add_subordinate stub from lib.rs.
L4: Deleted src/bin/testing_rust.rs (the only consumer of L3).

L5: Added middleware::DefaultHeaders setting X-Content-Type-Options:
    nosniff and X-Frame-Options: DENY on every response.