### PR TITLE
feat(collection): full Entity Collection 1.0 pagination and filters

### DIFF
--- a/docs/adr/0007-collection-endpoint-pagination-and-filters.md
+++ b/docs/adr/0007-collection-endpoint-pagination-and-filters.md
@@ -1,0 +1,79 @@
+# ADR 0007: Collection Endpoint Pagination and Filters
+
+## Status
+
+Accepted
+
+## Context
+
+The `/collection` endpoint serves federation entity data precomputed by the
+`inmor-collection` CLI. Measured against the OpenID Federation Entity
+Collection 1.0 specification (Section 3) it was incomplete: it supported only
+the `entity_type` filter, returned the whole list on every call, and rejected
+every other parameter with `unsupported_parameter`.
+
+Bringing the endpoint to Section 3 conformance required pagination
+(`from` / `limit` / `next`) and the `trust_mark_type`, `trust_anchor`, and
+`query` filters. Several of those raised design questions whose answers were
+not obvious and are worth recording.
+
+## Decision
+
+### Stateless pagination cursor
+
+The `from` and `next` pagination pointers are base64url-encoded `entity_id`
+values rather than server-side cursor tokens. Results are already ordered by
+`entity_id` (Section 3.1.1 requires a consistent order), so the last
+`entity_id` of a page is a sufficient resume point. The cursor is base64url
+encoded so clients treat it as opaque, as Section 3.4.1 intends.
+
+There is no cursor state to store or expire. The `page_not_found` error
+(Section 3.4.2) is therefore raised by checking whether the decoded
+`entity_id` still exists in the collection (`HEXISTS`), not by tracking which
+cursors were previously issued. A cursor that is not valid base64url is a
+malformed request and returns `invalid_request`.
+
+### Single precomputed collection
+
+`inmor-collection` walks one Trust Anchor and a walk overwrites all collection
+data. The endpoint records that Trust Anchor in
+`inmor:collection:trust_anchor`. A request `trust_anchor` parameter is
+validated against it: a match (or an omitted parameter) is served, a mismatch
+returns `invalid_request`. Per-Trust-Anchor namespaced collections were not
+adopted -- they would require reworking the CLI, the key model, and the
+atomic-swap logic for a multi-Trust-Anchor scenario inmor does not currently
+deploy.
+
+### Verify Trust Marks during the walk
+
+The `trust_mark_type` filter must match only entities with a Trust Mark that
+the responder has verified (Section 3.3.1-2.4.1). Verification happens in the
+`inmor-collection` walker -- reusing the same `verify_trust_marks` routine
+`/resolve` uses -- and only verified marks are indexed into
+`inmor:collection:by_trustmark:{type}`. Verification cost is thus paid once per
+walk, offline, instead of on every `/collection` request.
+
+### Dynamic by_trustmark keys vs. ADR 0004
+
+ADR 0004 removed the blocking Redis `KEYS` command by enumerating collection
+keys from a hardcoded list. Trust mark types are dynamic URLs, so the
+`by_trustmark:{type}` keys cannot be hardcoded. A registry set,
+`inmor:collection:trustmark_types`, records every indexed type; the
+atomic-swap logic reads it to enumerate the dynamic keys, preserving the
+no-`KEYS` guarantee. Because Redis `RENAME` errors on a missing source key,
+the swap first runs an `EXISTS` check and renames only the staging keys that
+were actually written during the walk.
+
+## Consequences
+
+- Pagination is memory-bounded per request and needs no cursor garbage
+  collection.
+- A re-walk that removes an entity invalidates any outstanding cursor pointing
+  at it; the client receives `page_not_found` and restarts, which the
+  `last_updated` response field already signals as a possibility.
+- The `inmor-collection` walk is slower: it now verifies every entity's Trust
+  Marks, which can involve outbound HTTP. This is acceptable for an offline
+  CLI and is bounded by the existing per-entity trust-mark cap.
+- `/collection` serves a single Trust Anchor's view. Supporting multiple Trust
+  Anchors concurrently is deferred and would supersede this ADR's
+  single-collection decision.

--- a/docs/api/trust-anchor.rst
+++ b/docs/api/trust-anchor.rst
@@ -516,6 +516,38 @@ This endpoint reads pre-populated data from Redis. The data is populated by runn
 ``inmor-collection`` CLI tool, which walks the federation tree from a trust anchor and
 stores entity information. See :ref:`collection-cli` for details.
 
+**Request Parameters:**
+
+All parameters are optional and passed as query parameters.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Parameter
+     - Description
+   * - ``entity_type``
+     - Repeatable. Filter to entities that include the given Entity Type.
+       Multiple values combine with **OR**.
+   * - ``trust_mark_type``
+     - Repeatable. Filter to entities that have a *verified* Trust Mark of the
+       given type. Multiple values combine with **AND**.
+   * - ``trust_anchor``
+     - The Trust Anchor the collection was built from. When omitted it
+       defaults to the collected Trust Anchor; a value that does not match it
+       returns ``invalid_request``.
+   * - ``query``
+     - Free-text filter. Matched case-insensitively as a substring against the
+       entity_id and any UI display names.
+   * - ``limit``
+     - Maximum number of entities in the response. Defaults to 100 and is
+       capped at 500.
+   * - ``from``
+     - Opaque pagination cursor. Pass the ``next`` value from a previous
+       response to fetch the following page.
+
+Filters of different kinds combine with **AND**.
+
 **Response (200 OK):**
 
 * Content-Type: ``application/json``
@@ -550,8 +582,12 @@ stores entity information. See :ref:`collection-cli` for details.
          }
        }
      ],
+     "next": "aHR0cHM6Ly9ycC5leGFtcGxlLmNvbQ",
      "last_updated": 1770983002
    }
+
+The ``next`` field is present only when more results are available beyond this
+page; pass it back as the ``from`` parameter to retrieve them.
 
 **Response Fields:**
 
@@ -571,6 +607,8 @@ stores entity information. See :ref:`collection-cli` for details.
      - Optional. UI information per entity type (display_name, logo_uri, policy_uri)
    * - ``entities[].trust_marks``
      - Optional. Array of trust marks attached to the entity
+   * - ``next``
+     - Optional. Opaque pagination cursor; present only when more results exist
    * - ``last_updated``
      - Unix timestamp of the last collection walk
 
@@ -582,6 +620,29 @@ stores entity information. See :ref:`collection-cli` for details.
 
 If no collection data has been populated yet, the response will be an empty entity list
 with ``last_updated: 0``.
+
+**Errors:**
+
+Error responses are JSON objects with ``error`` and ``error_description`` fields.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Error
+     - Status
+     - Cause
+   * - ``unsupported_parameter``
+     - 400
+     - The request used a query parameter the endpoint does not support
+   * - ``invalid_request``
+     - 400
+     - A malformed parameter -- a bad ``limit``, an unparseable ``from``
+       cursor, or a ``trust_anchor`` that does not match the collected one
+   * - ``page_not_found``
+     - 404
+     - The ``from`` cursor points at an entity the responder no longer knows;
+       restart pagination from the first page
 
 Index Page
 ^^^^^^^^^^

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -351,6 +351,20 @@ The Trust Anchor stores federation data in Redis:
      - Set of entity IDs with this trust mark type
    * - ``inmor:tm:alltime``
      - Set of all trust mark SHA256 hashes (for validation)
+   * - ``inmor:collection:entities``
+     - Hash: entity_id → JSON entity object (populated by ``inmor-collection``)
+   * - ``inmor:collection:by_type:{type}``
+     - Set of entity IDs of a given entity type
+   * - ``inmor:collection:by_trustmark:{type}``
+     - Set of entity IDs with a verified trust mark of a given type
+   * - ``inmor:collection:trustmark_types``
+     - Set: registry of indexed trust mark types
+   * - ``inmor:collection:trust_anchor``
+     - Entity Identifier the collection was walked from
+   * - ``inmor:collection:all_sorted``
+     - Sorted set of entity IDs for consistent ordering
+   * - ``inmor:collection:last_updated``
+     - Unix timestamp of the last collection walk
 
 Example Configuration Files
 ---------------------------

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -367,11 +367,15 @@ The ``/collection`` endpoint on the Trust Anchor reads this data.
 **How it works:**
 
 1. Connects to Redis using the URI from ``taconfig.toml``
-2. Fetches the trust anchor's entity configuration
+2. Fetches the trust anchor's entity configuration and extracts its trust mark
+   recognition maps (``trust_mark_issuers`` / ``trust_mark_owners``)
 3. Recursively discovers all subordinates by following ``federation_list_endpoint`` links
 4. For each entity, extracts entity types, UI info (display name, logo, policy URI), and trust marks
-5. Writes all data to **staging Redis keys** (``inmor:collection:staging:*``) during the walk
-6. On completion, atomically swaps staging keys to live keys using a Redis RENAME pipeline
+5. Verifies each entity's trust marks against the trust anchor and indexes the
+   verified ones by trust mark type, so the ``/collection`` ``trust_mark_type``
+   filter matches only verified marks
+6. Writes all data to **staging Redis keys** (``inmor:collection:staging:*``) during the walk
+7. On completion, atomically swaps staging keys to live keys using a Redis RENAME pipeline
 
 The staging-to-live swap ensures the ``/collection`` endpoint never serves partial data
 during a walk.
@@ -391,6 +395,15 @@ during a walk.
    * - ``inmor:collection:by_type:{type}``
      - Set
      - entity_ids of that type
+   * - ``inmor:collection:by_trustmark:{type}``
+     - Set
+     - entity_ids with a verified trust mark of that type
+   * - ``inmor:collection:trustmark_types``
+     - Set
+     - registry of indexed trust mark types (enumerates the ``by_trustmark`` keys)
+   * - ``inmor:collection:trust_anchor``
+     - String
+     - Entity Identifier the collection was walked from
    * - ``inmor:collection:all_sorted``
      - ZSet
      - entity_ids for ordering

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,21 +515,68 @@ pub fn create_signed_jwt_with_header(
     Ok(jwt)
 }
 
-/// Returns entities from the collection data populated by inmor-collection.
-/// If entity_type filter is given, reads from `inmor:collection:by_type:{type}` sets,
-/// otherwise reads all from `inmor:collection:entities` hash.
-async fn get_collection_entities(
+/// Default page size for `/collection` when `limit` is omitted.
+const COLLECTION_DEFAULT_LIMIT: usize = 100;
+/// Practical upper bound for a `/collection` page (spec sec 3.1.2).
+const COLLECTION_MAX_LIMIT: usize = 500;
+
+/// Clamps a requested `limit` to the supported range. `None` (parameter
+/// absent) falls back to the default page size.
+fn clamp_limit(requested: Option<usize>) -> usize {
+    match requested {
+        Some(n) => n.clamp(1, COLLECTION_MAX_LIMIT),
+        None => COLLECTION_DEFAULT_LIMIT,
+    }
+}
+
+/// Encodes an entity_id into the opaque pagination cursor carried by the
+/// `from` / `next` parameters.
+fn encode_cursor(entity_id: &str) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(entity_id)
+}
+
+/// Decodes a pagination cursor back into an entity_id. Returns `None` when the
+/// cursor is not valid base64url-encoded UTF-8.
+fn decode_cursor(cursor: &str) -> Option<String> {
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(cursor)
+        .ok()?;
+    String::from_utf8(bytes).ok()
+}
+
+/// Implementation-defined `query` filter (spec sec 3.3.1-2.6.1): a
+/// case-insensitive substring match over the entity_id and any UI display
+/// names.
+fn query_matches(entity: &EntityCollectionResponse, query: &str) -> bool {
+    let needle = query.to_lowercase();
+    if entity.entity_id.to_lowercase().contains(&needle) {
+        return true;
+    }
+    if let Some(ui_infos) = &entity.ui_infos {
+        for ui in ui_infos.values() {
+            if let Some(name) = &ui.display_name
+                && name.to_lowercase().contains(&needle)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Returns the entity_id-sorted candidate ids matching the `entity_type`
+/// (OR) and `trust_mark_type` (AND) filters. Only ids are read here -- no
+/// entity records are materialized -- so a paginated request can fetch just
+/// the page it serves rather than the whole filtered set.
+async fn collect_collection_ids(
     conn: &mut redis::aio::ConnectionManager,
     entity_types: &[String],
-) -> Result<Vec<EntityCollectionResponse>> {
-    let entity_ids: Vec<String> = if entity_types.is_empty() {
-        // No filter: get all entity_ids from the hash
-        redis::Cmd::hkeys("inmor:collection:entities")
-            .query_async(conn)
-            .await
-            .unwrap_or_default()
+    trust_mark_types: &[String],
+) -> Result<Vec<String>> {
+    // entity_type filter: union (OR) of by_type sets.
+    let etype_ids: Option<HashSet<String>> = if entity_types.is_empty() {
+        None
     } else {
-        // Get union of entity_ids across requested types
         let mut ids = HashSet::new();
         for etype in entity_types {
             validate_entity_type(etype)
@@ -541,11 +588,52 @@ async fn get_collection_entities(
                     .unwrap_or_default();
             ids.extend(type_ids);
         }
-        ids.into_iter().collect()
+        Some(ids)
     };
 
-    let mut result = Vec::new();
-    for eid in &entity_ids {
+    // trust_mark_type filter: intersection (AND) of by_trustmark sets.
+    let tmtype_ids: Option<HashSet<String>> = if trust_mark_types.is_empty() {
+        None
+    } else {
+        let mut acc: Option<HashSet<String>> = None;
+        for tmt in trust_mark_types {
+            let set: HashSet<String> =
+                redis::Cmd::smembers(format!("inmor:collection:by_trustmark:{tmt}"))
+                    .query_async(conn)
+                    .await
+                    .unwrap_or_default();
+            acc = Some(match acc {
+                None => set,
+                Some(prev) => prev.intersection(&set).cloned().collect(),
+            });
+        }
+        acc
+    };
+
+    // Combine the active filters (AND across filter kinds).
+    let mut entity_ids: Vec<String> = match (etype_ids, tmtype_ids) {
+        (None, None) => redis::Cmd::hkeys("inmor:collection:entities")
+            .query_async(conn)
+            .await
+            .unwrap_or_default(),
+        (Some(a), None) => a.into_iter().collect(),
+        (None, Some(b)) => b.into_iter().collect(),
+        (Some(a), Some(b)) => a.intersection(&b).cloned().collect(),
+    };
+
+    // Sort for consistent pagination ordering (spec sec 3.1.1).
+    entity_ids.sort();
+    Ok(entity_ids)
+}
+
+/// Fetches and deserializes the given entity records from the collection
+/// hash, preserving input order and skipping unreadable entries.
+async fn fetch_collection_records(
+    conn: &mut redis::aio::ConnectionManager,
+    ids: &[String],
+) -> Vec<EntityCollectionResponse> {
+    let mut records = Vec::with_capacity(ids.len());
+    for eid in ids {
         let json_str: Option<String> = redis::Cmd::hget("inmor:collection:entities", eid)
             .query_async(conn)
             .await
@@ -553,13 +641,57 @@ async fn get_collection_entities(
         if let Some(json_str) = json_str
             && let Ok(entry) = serde_json::from_str::<EntityCollectionResponse>(&json_str)
         {
-            result.push(entry);
+            records.push(entry);
         }
     }
+    records
+}
 
-    // Sort by entity_id for consistent ordering
-    result.sort_by(|a, b| a.entity_id.cmp(&b.entity_id));
-    Ok(result)
+/// Index of the first entity_id strictly greater than the `from` cursor in
+/// an ascending-sorted id slice -- i.e. the start of the page after the
+/// cursor. A `None` cursor starts at index 0. Binary search, since the slice
+/// is already sorted.
+fn page_start(sorted_ids: &[String], from: Option<&str>) -> usize {
+    match from {
+        None => 0,
+        Some(f) => sorted_ids.partition_point(|id| id.as_str() <= f),
+    }
+}
+
+/// Paginates the whole collection directly off the `all_sorted` ZSET. Used
+/// when no filter is active: `ZRANGEBYLEX` walks the ordered set from just
+/// after the cursor and fetches only one page, so the full id set is never
+/// loaded or sorted per request.
+async fn paginate_collection_zset(
+    conn: &mut redis::aio::ConnectionManager,
+    from: Option<&str>,
+    limit: usize,
+) -> (Vec<EntityCollectionResponse>, Option<String>) {
+    // `(value` is an exclusive lower bound; `-` is the start of the set.
+    let min = match from {
+        None => "-".to_string(),
+        Some(f) => format!("({f}"),
+    };
+    // Fetch one extra id to detect whether a further page exists.
+    let ids: Vec<String> = redis::cmd("ZRANGEBYLEX")
+        .arg("inmor:collection:all_sorted")
+        .arg(&min)
+        .arg("+")
+        .arg("LIMIT")
+        .arg(0)
+        .arg(limit + 1)
+        .query_async(conn)
+        .await
+        .unwrap_or_default();
+    let has_more = ids.len() > limit;
+    let page_ids: Vec<String> = ids.into_iter().take(limit).collect();
+    let next = if has_more {
+        page_ids.last().map(|id| encode_cursor(id))
+    } else {
+        None
+    };
+    let page = fetch_collection_records(conn, &page_ids).await;
+    (page, next)
 }
 
 /// TODO: We need to deal with query parameters in future
@@ -659,8 +791,10 @@ async fn list_subordinates(
     Ok(HttpResponse::Ok().json(res))
 }
 
-/// https://zachmann.github.io/openid-federation-entity-collection/main.html
-/// Entity collection endpoint. Reads data populated by inmor-collection CLI.
+/// Federation Entity Collection endpoint (Entity Collection spec sec 3).
+/// Reads data populated by the inmor-collection CLI. Supports `entity_type`
+/// (OR), `trust_mark_type` (AND), `trust_anchor`, and `query` filters plus
+/// `from` / `limit` pagination.
 #[get("/collection")]
 pub async fn fetch_collections(
     req: HttpRequest,
@@ -678,33 +812,159 @@ pub async fn fetch_collections(
         .map_err(error::ErrorInternalServerError)?;
 
     let mut entity_types: Vec<String> = Vec::new();
+    let mut trust_mark_types: Vec<String> = Vec::new();
+    let mut from_cursor: Option<String> = None;
+    let mut limit_param: Option<usize> = None;
+    let mut requested_ta: Option<String> = None;
+    let mut query: Option<String> = None;
 
-    // Parse query parameters
+    // Parse query parameters. Unknown parameters (including the optional
+    // entity_claims / ui_claims response-shaping parameters inmor does not
+    // implement) are rejected with unsupported_parameter per spec sec 3.4.2.
     for (q, p) in params.iter() {
         match q.as_str() {
-            "entity_type" => {
-                entity_types.push(p.clone());
+            "entity_type" => entity_types.push(p.clone()),
+            "trust_mark_type" => {
+                if let Err(e) = validate_redis_key_input(p) {
+                    return error_response_400(
+                        "invalid_request",
+                        &format!("invalid trust_mark_type: {e}"),
+                    );
+                }
+                trust_mark_types.push(p.clone());
             }
+            "from" => from_cursor = Some(p.clone()),
+            "limit" => match p.parse::<usize>() {
+                Ok(n) => limit_param = Some(n),
+                Err(_) => {
+                    return error_response_400(
+                        "invalid_request",
+                        "the 'limit' parameter must be a non-negative integer",
+                    );
+                }
+            },
+            "trust_anchor" => requested_ta = Some(p.clone()),
+            "query" => query = Some(p.clone()),
             _ => {
-                return error_response_400("unsupported_parameter", q);
+                return error_response_400(
+                    "unsupported_parameter",
+                    &format!("the '{q}' parameter is not supported by this endpoint"),
+                );
             }
         }
     }
 
-    let result = get_collection_entities(&mut conn, &entity_types)
-        .await
-        .map_err(error::ErrorInternalServerError)?;
-
-    // Get last_updated timestamp
-    let last_updated: Option<u64> = redis::Cmd::get("inmor:collection:last_updated")
+    // trust_anchor (spec sec 3.3.1-2.5.1): the collection is precomputed for a
+    // single Trust Anchor by the inmor-collection CLI. Accept the parameter
+    // only when it matches that Trust Anchor.
+    let collection_ta: Option<String> = redis::Cmd::get("inmor:collection:trust_anchor")
         .query_async(&mut conn)
         .await
         .ok();
+    if let Some(req_ta) = &requested_ta
+        && collection_ta.as_deref() != Some(req_ta.as_str())
+    {
+        return error_response_400(
+            "invalid_request",
+            "collection data is not available for the requested trust_anchor",
+        );
+    }
 
-    let response = json!({
-        "entities": result,
+    // Resolve the `from` cursor. page_not_found is checked against the full
+    // collection membership, independent of the active filters (spec sec 3.4.2).
+    let from_id: Option<String> = match &from_cursor {
+        None => None,
+        Some(cursor) => {
+            let Some(id) = decode_cursor(cursor) else {
+                return error_response_400(
+                    "invalid_request",
+                    "the 'from' parameter is not a valid pagination cursor",
+                );
+            };
+            let known: bool = redis::Cmd::hexists("inmor:collection:entities", &id)
+                .query_async(&mut conn)
+                .await
+                .unwrap_or(false);
+            if !known {
+                return error_response_404(
+                    "page_not_found",
+                    "the pagination pointer in 'from' is not or no longer known",
+                );
+            }
+            Some(id)
+        }
+    };
+
+    // Pagination (spec sec 3.1).
+    let limit = clamp_limit(limit_param);
+    let (page, next): (Vec<EntityCollectionResponse>, Option<String>) =
+        if entity_types.is_empty() && trust_mark_types.is_empty() && query.is_none() {
+            // No filter active: page straight off the ordered ZSET so the
+            // whole id set is never loaded just to serve one page.
+            paginate_collection_zset(&mut conn, from_id.as_deref(), limit).await
+        } else {
+            // A filter is active: resolve the candidate id set first.
+            let candidate_ids =
+                match collect_collection_ids(&mut conn, &entity_types, &trust_mark_types).await {
+                    Ok(ids) => ids,
+                    Err(e) => return error_response_400("invalid_request", &e.to_string()),
+                };
+            match query.as_deref() {
+                Some(q) => {
+                    // The query filter must inspect entity records, so the
+                    // candidate set is materialized before paging.
+                    let records: Vec<EntityCollectionResponse> =
+                        fetch_collection_records(&mut conn, &candidate_ids)
+                            .await
+                            .into_iter()
+                            .filter(|e| query_matches(e, q))
+                            .collect();
+                    let start = match from_id.as_deref() {
+                        None => 0,
+                        Some(f) => records.partition_point(|e| e.entity_id.as_str() <= f),
+                    };
+                    let has_more = start + limit < records.len();
+                    let page: Vec<EntityCollectionResponse> =
+                        records.into_iter().skip(start).take(limit).collect();
+                    let next = has_more
+                        .then(|| page.last().map(|e| encode_cursor(&e.entity_id)))
+                        .flatten();
+                    (page, next)
+                }
+                None => {
+                    // Type filter only: page the candidate ids, then fetch
+                    // only that page's records.
+                    let start = page_start(&candidate_ids, from_id.as_deref());
+                    let page_ids: Vec<String> = candidate_ids
+                        .iter()
+                        .skip(start)
+                        .take(limit)
+                        .cloned()
+                        .collect();
+                    let has_more = start + page_ids.len() < candidate_ids.len();
+                    let next = has_more
+                        .then(|| page_ids.last().map(|id| encode_cursor(id)))
+                        .flatten();
+                    let page = fetch_collection_records(&mut conn, &page_ids).await;
+                    (page, next)
+                }
+            }
+        };
+
+    // Default to 0 when no walk has populated the collection yet, so the
+    // response always carries a numeric `last_updated`.
+    let last_updated: u64 = redis::Cmd::get("inmor:collection:last_updated")
+        .query_async(&mut conn)
+        .await
+        .unwrap_or(0);
+
+    let mut response = json!({
+        "entities": page,
         "last_updated": last_updated,
     });
+    if let Some(next) = next {
+        response["next"] = json!(next);
+    }
 
     Ok(HttpResponse::Ok()
         .content_type("application/json")
@@ -2267,13 +2527,90 @@ async fn verify_single_trust_mark(
 ///
 /// The original `{trust_mark, trust_mark_type}` objects are returned unchanged so
 /// they can be embedded verbatim in the resolve response (per spec §8.3.2).
+/// Loads the federation recognition maps (`trust_mark_issuers` /
+/// `trust_mark_owners`) from inmor's own published Entity Configuration
+/// (`inmor:entity_id`). Returns empty maps when the EC is missing or its
+/// `trust_mark_owners` claim is malformed -- callers treat empty maps as
+/// "recognise nothing", which fails closed.
+pub async fn load_inmor_recognition_maps(
+    conn: &mut redis::aio::ConnectionManager,
+) -> (Map<String, Value>, TrustMarkOwners) {
+    // We trust Redis here -- it's our own data written by the admin process.
+    // Skipping the signature check is intentional: it avoids a needless
+    // self-verify on every resolve and matches the trust boundary used by
+    // other endpoints that read `inmor:entity_id`.
+    let ta_ec_jwt: String = match redis::Cmd::get("inmor:entity_id")
+        .query_async::<String>(conn)
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("trust mark resolve: failed to GET inmor:entity_id from Redis: {e}");
+            return (Map::new(), TrustMarkOwners::default());
+        }
+    };
+    let (ta_payload, _) = match get_unverified_payload_header(&ta_ec_jwt) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("trust mark resolve: failed to parse TA entity configuration: {e}");
+            return (Map::new(), TrustMarkOwners::default());
+        }
+    };
+    let issuers = ta_payload
+        .claim("trust_mark_issuers")
+        .and_then(|v| v.as_object())
+        .cloned()
+        .unwrap_or_default();
+    // FAIL-CLOSED on malformed `trust_mark_owners`: a broken owners claim in
+    // the TA's own EC would otherwise silently disable delegation enforcement
+    // for any owned type also listed in `trust_mark_issuers`.
+    let owners = match TrustMarkOwners::from_ta_payload(&ta_payload) {
+        Ok(o) => o,
+        Err(e) => {
+            warn!(
+                "trust mark resolve: malformed trust_mark_owners claim in TA EC ({e}); refusing trust marks until operator fixes it"
+            );
+            return (Map::new(), TrustMarkOwners::default());
+        }
+    };
+    (issuers, owners)
+}
+
+/// Thin wrapper over `verify_trust_marks` that sources the federation
+/// recognition maps from inmor's own published Entity Configuration. Used by
+/// `/resolve`.
 async fn verify_trust_marks_for_resolve(
     subject_payload: &JwtPayload,
     ta_entity_id: &str,
     ta_public_keyset: &JwkSet,
     conn: &mut redis::aio::ConnectionManager,
 ) -> Vec<Value> {
-    // 1. Subject's trust marks.
+    let (trust_mark_issuers, trust_mark_owners) = load_inmor_recognition_maps(conn).await;
+    verify_trust_marks(
+        subject_payload,
+        ta_entity_id,
+        ta_public_keyset,
+        &trust_mark_issuers,
+        &trust_mark_owners,
+        conn,
+    )
+    .await
+}
+
+/// Core trust-mark verification: given the federation recognition maps
+/// (`trust_mark_issuers` / `trust_mark_owners`), returns the subset of the
+/// subject's trust marks that verify. Shared by `/resolve` and the
+/// `inmor-collection` walker so marks are verified against the same Trust
+/// Anchor used to build the trust chain / collection (spec sec 3.3.1-2.4.1).
+pub async fn verify_trust_marks(
+    subject_payload: &JwtPayload,
+    ta_entity_id: &str,
+    ta_public_keyset: &JwkSet,
+    trust_mark_issuers: &Map<String, Value>,
+    trust_mark_owners: &TrustMarkOwners,
+    conn: &mut redis::aio::ConnectionManager,
+) -> Vec<Value> {
+    // Subject's trust marks.
     let trust_marks = match subject_payload
         .claim("trust_marks")
         .and_then(|v| v.as_array())
@@ -2288,53 +2625,6 @@ async fn verify_trust_marks_for_resolve(
     // accepted as its own.
     let resolve_sub = subject_payload.subject().unwrap_or("");
 
-    // 2. TA's own entity configuration → trust_mark_issuers map.
-    let ta_ec_jwt: String = match redis::Cmd::get("inmor:entity_id")
-        .query_async::<String>(conn)
-        .await
-    {
-        Ok(s) => s,
-        Err(e) => {
-            warn!("trust mark resolve: failed to GET inmor:entity_id from Redis: {e}");
-            return Vec::new();
-        }
-    };
-    // We trust Redis here — it's our own data written by the admin process.
-    // Skipping the signature check is intentional: it avoids a needless self-verify
-    // on every resolve and matches the trust boundary used by other endpoints that
-    // read `inmor:entity_id`.
-    let (ta_payload, _) = match get_unverified_payload_header(&ta_ec_jwt) {
-        Ok(p) => p,
-        Err(e) => {
-            warn!("trust mark resolve: failed to parse TA entity configuration: {e}");
-            return Vec::new();
-        }
-    };
-    let trust_mark_issuers = ta_payload
-        .claim("trust_mark_issuers")
-        .and_then(|v| v.as_object())
-        .cloned()
-        .unwrap_or_default();
-    // Trust Mark Owners pinned by the TA (spec sec 7.2). Parsed from the same
-    // TA EC payload.
-    //
-    // FAIL-CLOSED on malformed `trust_mark_owners`: if the TA's own EC has
-    // a broken owners claim, fall back to an empty result. Treating it as
-    // "no owners pinned" would silently disable delegation enforcement for
-    // any owned type that is *also* listed in `trust_mark_issuers` -- a
-    // mark of that type would fall through to the issuer allowlist and be
-    // accepted without delegation validation. A malformed TA EC is an
-    // operator bug and the right reaction is to refuse trust marks until
-    // the EC is regenerated cleanly.
-    let trust_mark_owners = match TrustMarkOwners::from_ta_payload(&ta_payload) {
-        Ok(o) => o,
-        Err(e) => {
-            warn!(
-                "trust mark resolve: malformed trust_mark_owners claim in TA EC ({e}); refusing trust marks until operator fixes it"
-            );
-            return Vec::new();
-        }
-    };
     // A mark is *recognised* if either:
     //   * its trust_mark_type appears in trust_mark_issuers (federation-pinned
     //     recognition list, may be empty meaning "any issuer"), OR
@@ -2347,7 +2637,7 @@ async fn verify_trust_marks_for_resolve(
         return Vec::new();
     }
 
-    // 3. Filter and verify each mark.
+    // Filter and verify each mark.
     //
     // Hard cap: bounds the per-request HTTP fan-out (each external mark may
     // trigger two outbound calls). See MAX_TRUST_MARKS_PER_RESOLVE.
@@ -2458,7 +2748,7 @@ async fn verify_trust_marks_for_resolve(
             ta_public_keyset,
             conn,
             &mut issuer_cache,
-            &trust_mark_owners,
+            trust_mark_owners,
             tm_type,
         )
         .await
@@ -3048,7 +3338,7 @@ const KNOWN_ENTITY_TYPES: &[&str] = &[
 /// Validates that a user-supplied string is safe to use in a Redis key.
 /// Rejects control characters (including newlines and null bytes) and
 /// enforces a maximum length to prevent memory abuse.
-fn validate_redis_key_input(input: &str) -> Result<(), &'static str> {
+pub(crate) fn validate_redis_key_input(input: &str) -> Result<(), &'static str> {
     const MAX_KEY_INPUT_LEN: usize = 2048;
     if input.is_empty() {
         return Err("empty value");
@@ -4798,5 +5088,91 @@ mod ssrf_tests {
             .unwrap();
         let result = get_jwks_from_payload(&payload);
         assert!(result.is_ok());
+    }
+}
+
+#[cfg(test)]
+mod collection_tests {
+    use super::*;
+
+    #[test]
+    fn test_clamp_limit() {
+        // Absent parameter falls back to the default page size.
+        assert_eq!(clamp_limit(None), COLLECTION_DEFAULT_LIMIT);
+        assert_eq!(clamp_limit(Some(10)), 10);
+        // Zero is clamped up to a usable page size.
+        assert_eq!(clamp_limit(Some(0)), 1);
+        // Oversized requests are capped at the upper bound.
+        assert_eq!(
+            clamp_limit(Some(COLLECTION_MAX_LIMIT + 1000)),
+            COLLECTION_MAX_LIMIT
+        );
+        assert_eq!(
+            clamp_limit(Some(COLLECTION_MAX_LIMIT)),
+            COLLECTION_MAX_LIMIT
+        );
+    }
+
+    #[test]
+    fn test_page_start() {
+        let ids: Vec<String> = ["a", "b", "c", "d"].iter().map(|s| s.to_string()).collect();
+        // No cursor starts at the beginning.
+        assert_eq!(page_start(&ids, None), 0);
+        // Resume strictly after the cursor entity.
+        assert_eq!(page_start(&ids, Some("b")), 2);
+        // A cursor at or past the last id yields the end index (empty page).
+        assert_eq!(page_start(&ids, Some("d")), 4);
+        assert_eq!(page_start(&ids, Some("z")), 4);
+        // A cursor falling between ids resumes at the next one.
+        assert_eq!(page_start(&ids, Some("bb")), 2);
+    }
+
+    #[test]
+    fn test_cursor_round_trip() {
+        let id = "https://rp.example.com/path?x=1";
+        let cursor = encode_cursor(id);
+        // The cursor is opaque -- not the raw entity_id.
+        assert_ne!(cursor, id);
+        assert_eq!(decode_cursor(&cursor).as_deref(), Some(id));
+    }
+
+    #[test]
+    fn test_decode_cursor_rejects_garbage() {
+        // Not valid base64url-encoded UTF-8.
+        assert_eq!(decode_cursor("!!!not base64!!!"), None);
+    }
+
+    #[test]
+    fn test_query_matches_entity_id() {
+        let e = EntityCollectionResponse::new(
+            "https://OP.example.com".to_string(),
+            vec!["openid_provider".to_string()],
+        );
+        // Case-insensitive substring match on entity_id.
+        assert!(query_matches(&e, "op.example"));
+        assert!(query_matches(&e, "OP.EXAMPLE"));
+        assert!(!query_matches(&e, "missing"));
+    }
+
+    #[test]
+    fn test_query_matches_display_name() {
+        let mut ui = HashMap::new();
+        ui.insert(
+            "openid_provider".to_string(),
+            UiInfo {
+                display_name: Some("Example University".to_string()),
+                description: None,
+                logo_uri: None,
+                policy_uri: None,
+                information_uri: None,
+            },
+        );
+        let mut e = EntityCollectionResponse::new(
+            "https://op.example.com".to_string(),
+            vec!["openid_provider".to_string()],
+        );
+        e.ui_infos = Some(ui);
+        assert!(query_matches(&e, "university"));
+        assert!(!query_matches(&e, "college"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,16 +546,16 @@ fn decode_cursor(cursor: &str) -> Option<String> {
 
 /// Implementation-defined `query` filter (spec sec 3.3.1-2.6.1): a
 /// case-insensitive substring match over the entity_id and any UI display
-/// names.
-fn query_matches(entity: &EntityCollectionResponse, query: &str) -> bool {
-    let needle = query.to_lowercase();
-    if entity.entity_id.to_lowercase().contains(&needle) {
+/// names. `needle` must already be lowercased; the caller lowercases the
+/// request `query` string once so the per-entity check stays allocation-free.
+fn query_matches(entity: &EntityCollectionResponse, needle: &str) -> bool {
+    if entity.entity_id.to_lowercase().contains(needle) {
         return true;
     }
     if let Some(ui_infos) = &entity.ui_infos {
         for ui in ui_infos.values() {
             if let Some(name) = &ui.display_name
-                && name.to_lowercase().contains(&needle)
+                && name.to_lowercase().contains(needle)
             {
                 return true;
             }
@@ -685,12 +685,18 @@ async fn paginate_collection_zset(
         .unwrap_or_default();
     let has_more = ids.len() > limit;
     let page_ids: Vec<String> = ids.into_iter().take(limit).collect();
+    let page = fetch_collection_records(conn, &page_ids).await;
+    // Anchor `next` on the last entity actually returned so a cursor never
+    // points at an id that was dropped by `fetch_collection_records` (e.g.
+    // because the hash entry is missing). When the page is empty but more
+    // ids exist upstream we have no entity to anchor on, so pagination
+    // stops here -- a clearer signal than handing the client back an id
+    // that would 404 on the next request.
     let next = if has_more {
-        page_ids.last().map(|id| encode_cursor(id))
+        page.last().map(|e| encode_cursor(&e.entity_id))
     } else {
         None
     };
-    let page = fetch_collection_records(conn, &page_ids).await;
     (page, next)
 }
 
@@ -912,12 +918,14 @@ pub async fn fetch_collections(
             match query.as_deref() {
                 Some(q) => {
                     // The query filter must inspect entity records, so the
-                    // candidate set is materialized before paging.
+                    // candidate set is materialized before paging. Lowercase
+                    // the needle once for the whole filter pass.
+                    let needle = q.to_lowercase();
                     let records: Vec<EntityCollectionResponse> =
                         fetch_collection_records(&mut conn, &candidate_ids)
                             .await
                             .into_iter()
-                            .filter(|e| query_matches(e, q))
+                            .filter(|e| query_matches(e, &needle))
                             .collect();
                     let start = match from_id.as_deref() {
                         None => 0,
@@ -942,10 +950,13 @@ pub async fn fetch_collections(
                         .cloned()
                         .collect();
                     let has_more = start + page_ids.len() < candidate_ids.len();
-                    let next = has_more
-                        .then(|| page_ids.last().map(|id| encode_cursor(id)))
-                        .flatten();
                     let page = fetch_collection_records(&mut conn, &page_ids).await;
+                    // Anchor `next` on the last entity actually returned so
+                    // the cursor can never point at an id that was dropped
+                    // while materializing records.
+                    let next = has_more
+                        .then(|| page.last().map(|e| encode_cursor(&e.entity_id)))
+                        .flatten();
                     (page, next)
                 }
             }
@@ -5148,9 +5159,9 @@ mod collection_tests {
             "https://OP.example.com".to_string(),
             vec!["openid_provider".to_string()],
         );
-        // Case-insensitive substring match on entity_id.
+        // The needle is precomputed lowercase by the caller; the matcher
+        // lowercases the haystack so mixed-case entity_ids still match.
         assert!(query_matches(&e, "op.example"));
-        assert!(query_matches(&e, "OP.EXAMPLE"));
         assert!(!query_matches(&e, "missing"));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,8 +546,10 @@ fn decode_cursor(cursor: &str) -> Option<String> {
 
 /// Implementation-defined `query` filter (spec sec 3.3.1-2.6.1): a
 /// case-insensitive substring match over the entity_id and any UI display
-/// names. `needle` must already be lowercased; the caller lowercases the
-/// request `query` string once so the per-entity check stays allocation-free.
+/// names. `needle` must already be lowercased by the caller -- this avoids
+/// reallocating the query string on every entity. The haystacks are still
+/// lowercased per match because Unicode case folding cannot be done in
+/// place without allocating.
 fn query_matches(entity: &EntityCollectionResponse, needle: &str) -> bool {
     if entity.entity_id.to_lowercase().contains(needle) {
         return true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,20 +574,21 @@ async fn collect_collection_ids(
     conn: &mut redis::aio::ConnectionManager,
     entity_types: &[String],
     trust_mark_types: &[String],
-) -> Result<Vec<String>> {
+) -> actix_web::Result<Vec<String>> {
     // entity_type filter: union (OR) of by_type sets.
     let etype_ids: Option<HashSet<String>> = if entity_types.is_empty() {
         None
     } else {
         let mut ids = HashSet::new();
         for etype in entity_types {
-            validate_entity_type(etype)
-                .map_err(|e| anyhow!("invalid entity_type '{}': {}", etype, e))?;
+            validate_entity_type(etype).map_err(|e| {
+                error::ErrorBadRequest(format!("invalid entity_type '{}': {}", etype, e))
+            })?;
             let type_ids: Vec<String> =
                 redis::Cmd::smembers(format!("inmor:collection:by_type:{etype}"))
                     .query_async(conn)
                     .await
-                    .unwrap_or_default();
+                    .map_err(error::ErrorInternalServerError)?;
             ids.extend(type_ids);
         }
         Some(ids)
@@ -603,7 +604,7 @@ async fn collect_collection_ids(
                 redis::Cmd::smembers(format!("inmor:collection:by_trustmark:{tmt}"))
                     .query_async(conn)
                     .await
-                    .unwrap_or_default();
+                    .map_err(error::ErrorInternalServerError)?;
             acc = Some(match acc {
                 None => set,
                 Some(prev) => prev.intersection(&set).cloned().collect(),
@@ -617,7 +618,7 @@ async fn collect_collection_ids(
         (None, None) => redis::Cmd::hkeys("inmor:collection:entities")
             .query_async(conn)
             .await
-            .unwrap_or_default(),
+            .map_err(error::ErrorInternalServerError)?,
         (Some(a), None) => a.into_iter().collect(),
         (None, Some(b)) => b.into_iter().collect(),
         (Some(a), Some(b)) => a.intersection(&b).cloned().collect(),
@@ -668,7 +669,7 @@ async fn paginate_collection_zset(
     conn: &mut redis::aio::ConnectionManager,
     from: Option<&str>,
     limit: usize,
-) -> (Vec<EntityCollectionResponse>, Option<String>) {
+) -> actix_web::Result<(Vec<EntityCollectionResponse>, Option<String>)> {
     // `(value` is an exclusive lower bound; `-` is the start of the set.
     let min = match from {
         None => "-".to_string(),
@@ -684,7 +685,7 @@ async fn paginate_collection_zset(
         .arg(limit + 1)
         .query_async(conn)
         .await
-        .unwrap_or_default();
+        .map_err(error::ErrorInternalServerError)?;
     let has_more = ids.len() > limit;
     let page_ids: Vec<String> = ids.into_iter().take(limit).collect();
     let page = fetch_collection_records(conn, &page_ids).await;
@@ -699,7 +700,7 @@ async fn paginate_collection_zset(
     } else {
         None
     };
-    (page, next)
+    Ok((page, next))
 }
 
 /// TODO: We need to deal with query parameters in future
@@ -868,7 +869,7 @@ pub async fn fetch_collections(
     let collection_ta: Option<String> = redis::Cmd::get("inmor:collection:trust_anchor")
         .query_async(&mut conn)
         .await
-        .ok();
+        .map_err(error::ErrorInternalServerError)?;
     if let Some(req_ta) = &requested_ta
         && collection_ta.as_deref() != Some(req_ta.as_str())
     {
@@ -892,7 +893,7 @@ pub async fn fetch_collections(
             let known: bool = redis::Cmd::hexists("inmor:collection:entities", &id)
                 .query_async(&mut conn)
                 .await
-                .unwrap_or(false);
+                .map_err(error::ErrorInternalServerError)?;
             if !known {
                 return error_response_404(
                     "page_not_found",
@@ -909,14 +910,11 @@ pub async fn fetch_collections(
         if entity_types.is_empty() && trust_mark_types.is_empty() && query.is_none() {
             // No filter active: page straight off the ordered ZSET so the
             // whole id set is never loaded just to serve one page.
-            paginate_collection_zset(&mut conn, from_id.as_deref(), limit).await
+            paginate_collection_zset(&mut conn, from_id.as_deref(), limit).await?
         } else {
             // A filter is active: resolve the candidate id set first.
             let candidate_ids =
-                match collect_collection_ids(&mut conn, &entity_types, &trust_mark_types).await {
-                    Ok(ids) => ids,
-                    Err(e) => return error_response_400("invalid_request", &e.to_string()),
-                };
+                collect_collection_ids(&mut conn, &entity_types, &trust_mark_types).await?;
             match query.as_deref() {
                 Some(q) => {
                     // The query filter must inspect entity records, so the

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -4,15 +4,16 @@
 //! subordinate entities and storing their collection data in Redis.
 
 use anyhow::Result;
-use log::{debug, error, info};
-use serde_json::Value;
+use josekit::jwk::JwkSet;
+use log::{debug, error, info, warn};
+use serde_json::{Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
-    EntityCollectionResponse, UiInfo, get_entity_configruation_as_jwt,
+    EntityCollectionResponse, TrustMarkOwners, UiInfo, get_entity_configruation_as_jwt,
     get_jwks_from_payload_or_uri, get_query, get_unverified_payload_header, self_verify_jwt,
-    verify_jwt_with_jwks,
+    validate_redis_key_input, verify_jwt_with_jwks, verify_trust_marks,
 };
 
 /// Prefix for staging keys used during tree walk.
@@ -28,6 +29,21 @@ const KNOWN_ENTITY_TYPES: &[&str] = &[
     "oauth_client",
     "oauth_resource",
 ];
+
+/// Federation context captured once from the walk-from Trust Anchor's Entity
+/// Configuration and threaded through the recursion. Lets the walker verify
+/// each entity's Trust Marks against the same Trust Anchor used to collect the
+/// federation (spec sec 3.3.1-2.4.1).
+struct CollectionWalkContext {
+    /// Entity Identifier of the Trust Anchor the walk started from.
+    trust_anchor: String,
+    /// The Trust Anchor's federation signing keys.
+    ta_keyset: JwkSet,
+    /// `trust_mark_issuers` recognition map from the Trust Anchor's EC.
+    trust_mark_issuers: Map<String, Value>,
+    /// `trust_mark_owners` pinned by the Trust Anchor.
+    trust_mark_owners: TrustMarkOwners,
+}
 
 /// Fetches authority subordinate statements and stores them in Redis.
 async fn fetch_all_subordinate_statements(
@@ -184,6 +200,7 @@ async fn collection_tree_walking(
     conn: &mut redis::aio::ConnectionManager,
     visited: &mut HashSet<String>,
     depth: u8,
+    ctx: &CollectionWalkContext,
 ) {
     if depth > MAX_COLLECTION_DEPTH {
         error!(
@@ -312,6 +329,45 @@ async fn collection_tree_walking(
         debug!("Entity {entity_id} has {} trust mark(s)", tms.len());
     }
 
+    // Verify the entity's Trust Marks against the walk-from Trust Anchor so the
+    // trust_mark_type collection filter indexes only marks that actually pass
+    // verification (spec sec 3.3.1-2.4.1). The response `trust_marks` field
+    // keeps the raw array -- per Entity Collection spec sec 6.1 the returned
+    // marks are informational and MAY be unverified.
+    let verified_marks = verify_trust_marks(
+        &payload,
+        &ctx.trust_anchor,
+        &ctx.ta_keyset,
+        &ctx.trust_mark_issuers,
+        &ctx.trust_mark_owners,
+        conn,
+    )
+    .await;
+    // The trust mark type strings are federation-provided and get used
+    // verbatim in Redis key names (`...:by_trustmark:{tm_type}`). Drop any
+    // value with control characters or an abusive length before indexing it.
+    let verified_tm_types: Vec<String> = verified_marks
+        .iter()
+        .filter_map(|m| {
+            m.get("trust_mark_type")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+        })
+        .filter(|tm_type| match validate_redis_key_input(tm_type) {
+            Ok(()) => true,
+            Err(e) => {
+                warn!("Skipping unsafe trust mark type for {entity_id}: {e}");
+                false
+            }
+        })
+        .collect();
+    if !verified_tm_types.is_empty() {
+        debug!(
+            "Entity {entity_id} has {} verified trust mark type(s)",
+            verified_tm_types.len()
+        );
+    }
+
     // Build collection response
     let response = EntityCollectionResponse {
         entity_id: entity_id.to_string(),
@@ -347,6 +403,22 @@ async fn collection_tree_walking(
         redis::Cmd::zadd(format!("{STAGING_PREFIX}:all_sorted"), entity_id, 0i64)
             .query_async(conn)
             .await;
+
+    // Index verified trust mark types so the trust_mark_type filter can
+    // resolve entities by type. `trustmark_types` is a registry of every
+    // indexed type, needed because by_trustmark keys are dynamic URLs.
+    for tm_type in &verified_tm_types {
+        let _: Result<(), _> = redis::Cmd::sadd(
+            format!("{STAGING_PREFIX}:by_trustmark:{tm_type}"),
+            entity_id,
+        )
+        .query_async(conn)
+        .await;
+        let _: Result<(), _> =
+            redis::Cmd::sadd(format!("{STAGING_PREFIX}:trustmark_types"), tm_type)
+                .query_async(conn)
+                .await;
+    }
 
     // Also populate the existing inmor:op/rp/taia sets for backward compat
     if metadata.contains_key("openid_relying_party") {
@@ -389,8 +461,14 @@ async fn collection_tree_walking(
                                 continue;
                             }
                             info!("Found subordinate: {sub_str}");
-                            Box::pin(collection_tree_walking(sub_str, conn, visited, depth + 1))
-                                .await;
+                            Box::pin(collection_tree_walking(
+                                sub_str,
+                                conn,
+                                visited,
+                                depth + 1,
+                                ctx,
+                            ))
+                            .await;
                         }
                     }
                 }
@@ -406,12 +484,74 @@ async fn collection_tree_walking(
 
 /// Returns the list of known collection Redis keys for a given prefix.
 /// This avoids using the KEYS command which blocks the Redis event loop.
-fn known_collection_keys(prefix: &str) -> Vec<String> {
-    let mut keys = vec![format!("{prefix}:entities"), format!("{prefix}:all_sorted")];
+///
+/// `trustmark_types` enumerates the dynamic `by_trustmark:{type}` keys; pass
+/// the trust mark types recorded in the matching `trustmark_types` registry
+/// set for the prefix.
+fn known_collection_keys(prefix: &str, trustmark_types: &[String]) -> Vec<String> {
+    let mut keys = vec![
+        format!("{prefix}:entities"),
+        format!("{prefix}:all_sorted"),
+        format!("{prefix}:trust_anchor"),
+        format!("{prefix}:trustmark_types"),
+    ];
     for etype in KNOWN_ENTITY_TYPES {
         keys.push(format!("{prefix}:by_type:{etype}"));
     }
+    for tm_type in trustmark_types {
+        keys.push(format!("{prefix}:by_trustmark:{tm_type}"));
+    }
     keys
+}
+
+/// Fetches and verifies the walk-from Trust Anchor's Entity Configuration and
+/// extracts the recognition context used for Trust Mark verification.
+async fn build_walk_context(
+    trust_anchor: &str,
+    conn: &mut redis::aio::ConnectionManager,
+) -> Result<CollectionWalkContext> {
+    let jwt = get_entity_configruation_as_jwt(trust_anchor).await?;
+    let (payload, _) = match self_verify_jwt(&jwt) {
+        Ok(data) => data,
+        Err(_) => {
+            // Self-verification failed -- try the jwks_uri fallback.
+            let (unverified, _) = get_unverified_payload_header(&jwt)?;
+            let keyset = get_jwks_from_payload_or_uri(&unverified, conn).await?;
+            verify_jwt_with_jwks(&jwt, Some(keyset))?
+        }
+    };
+    // Resolve the Trust Anchor's federation keys allowing the jwks_uri /
+    // signed_jwks_uri fallback, so collection also works for a Trust Anchor
+    // that publishes its keys by reference rather than inline.
+    let ta_keyset = get_jwks_from_payload_or_uri(&payload, conn).await?;
+    // Recognition maps. A malformed `trust_mark_owners` claim fails closed:
+    // both maps are emptied so no trust mark is recognised. Keeping
+    // `trust_mark_issuers` while dropping owners would silently skip
+    // delegation enforcement for owned types that also appear in the issuers
+    // map (the fail-open case documented on `TrustMarkOwners::from_ta_payload`).
+    let (trust_mark_issuers, trust_mark_owners) = match TrustMarkOwners::from_ta_payload(&payload) {
+        Ok(owners) => {
+            let issuers = payload
+                .claim("trust_mark_issuers")
+                .and_then(|v| v.as_object())
+                .cloned()
+                .unwrap_or_default();
+            (issuers, owners)
+        }
+        Err(e) => {
+            error!(
+                "Trust anchor {trust_anchor} has a malformed trust_mark_owners claim ({e}); \
+                 collection will recognise no trust marks at all"
+            );
+            (Map::new(), TrustMarkOwners::default())
+        }
+    };
+    Ok(CollectionWalkContext {
+        trust_anchor: trust_anchor.to_string(),
+        ta_keyset,
+        trust_mark_issuers,
+        trust_mark_owners,
+    })
 }
 
 /// Runs a full collection walk starting from the given trust anchor.
@@ -424,42 +564,83 @@ pub async fn run_collection_walk(
 ) -> Result<usize> {
     info!("Starting collection walk from {trust_anchor}");
 
-    // Clean any leftover staging data
-    let staging_keys = known_collection_keys(STAGING_PREFIX);
+    // Build the walk context (recognition maps + TA keys) up front. A failure
+    // here aborts before any live data is touched.
+    let ctx = build_walk_context(trust_anchor, conn).await?;
+
+    // Clean any leftover staging data, including dynamic by_trustmark keys
+    // left behind by a previous interrupted run.
+    let stale_types: Vec<String> =
+        redis::Cmd::smembers(format!("{STAGING_PREFIX}:trustmark_types"))
+            .query_async(conn)
+            .await
+            .unwrap_or_default();
+    let staging_keys = known_collection_keys(STAGING_PREFIX, &stale_types);
     debug!(
         "Cleaning {} possible leftover staging key(s)",
         staging_keys.len()
     );
     let _: Result<(), _> = redis::cmd("DEL").arg(&staging_keys).query_async(conn).await;
 
+    // Record the Trust Anchor this collection was built from so /collection
+    // can validate the request `trust_anchor` parameter against it.
+    let _: Result<(), _> = redis::Cmd::set(format!("{STAGING_PREFIX}:trust_anchor"), trust_anchor)
+        .query_async(conn)
+        .await;
+
     // Walk the tree
     debug!("Beginning recursive tree walk from {trust_anchor}");
     let mut visited = HashSet::new();
-    collection_tree_walking(trust_anchor, conn, &mut visited, 0).await;
+    collection_tree_walking(trust_anchor, conn, &mut visited, 0, &ctx).await;
 
     let entity_count = visited.len();
     info!("Walk complete: {entity_count} entities discovered");
 
-    // Atomic swap: delete old live keys, rename staging → live
-    debug!("Preparing atomic swap of staging → live keys");
+    // Atomic swap: delete old live keys, rename staging -> live.
+    debug!("Preparing atomic swap of staging -> live keys");
+
+    // Trust mark types discovered in this walk drive the staging by_trustmark
+    // key set; the previous live set drives the old-key cleanup.
+    let new_types: Vec<String> = redis::Cmd::smembers(format!("{STAGING_PREFIX}:trustmark_types"))
+        .query_async(conn)
+        .await
+        .unwrap_or_default();
+    let old_types: Vec<String> = redis::Cmd::smembers("inmor:collection:trustmark_types")
+        .query_async(conn)
+        .await
+        .unwrap_or_default();
+
+    // RENAME errors on a missing source key, so swap only the staging keys
+    // actually written during this walk.
+    let candidate_staging = known_collection_keys(STAGING_PREFIX, &new_types);
+    let mut exists_pipe = redis::pipe();
+    for key in &candidate_staging {
+        exists_pipe.cmd("EXISTS").arg(key);
+    }
+    let exists_flags: Vec<bool> = exists_pipe.query_async(conn).await?;
+    let existing_staging: Vec<&String> = candidate_staging
+        .iter()
+        .zip(exists_flags)
+        .filter_map(|(key, exists)| if exists { Some(key) } else { None })
+        .collect();
+
     let mut pipe = redis::pipe();
 
-    // Delete old live collection keys
-    let mut live_keys = known_collection_keys("inmor:collection");
+    // Delete old live collection keys.
+    let mut live_keys = known_collection_keys("inmor:collection", &old_types);
     live_keys.push("inmor:collection:last_updated".to_string());
     debug!("Deleting {} old live key(s)", live_keys.len());
     pipe.cmd("DEL").arg(&live_keys).ignore();
 
-    // Rename staging keys to live
-    let staging_keys = known_collection_keys(STAGING_PREFIX);
-    debug!("Renaming {} staging key(s) to live", staging_keys.len());
-    for staging_key in &staging_keys {
+    // Rename staging keys to live.
+    debug!("Renaming {} staging key(s) to live", existing_staging.len());
+    for staging_key in &existing_staging {
         let live_key = staging_key.replace("inmor:collection:staging:", "inmor:collection:");
-        debug!("  {staging_key} → {live_key}");
-        pipe.cmd("RENAME").arg(staging_key).arg(&live_key).ignore();
+        debug!("  {staging_key} -> {live_key}");
+        pipe.cmd("RENAME").arg(*staging_key).arg(&live_key).ignore();
     }
 
-    // Set last_updated timestamp
+    // Set last_updated timestamp.
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -353,6 +353,8 @@ async fn collection_tree_walking(
     // The trust mark type strings are federation-provided and get used
     // verbatim in Redis key names (`...:by_trustmark:{tm_type}`). Drop any
     // value with control characters or an abusive length before indexing it.
+    // Collect into a set so duplicate trust mark types on one entity only
+    // trigger one Redis SADD (and at most one index-write error count bump).
     let verified_tm_types: HashSet<String> = verified_marks
         .iter()
         .filter_map(|m| {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,7 +3,7 @@
 //! Walks a federation tree starting from a trust anchor, discovering all
 //! subordinate entities and storing their collection data in Redis.
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use josekit::jwk::JwkSet;
 use log::{debug, error, info, warn};
 use serde_json::{Map, Value};
@@ -353,7 +353,7 @@ async fn collection_tree_walking(
     // The trust mark type strings are federation-provided and get used
     // verbatim in Redis key names (`...:by_trustmark:{tm_type}`). Drop any
     // value with control characters or an abusive length before indexing it.
-    let verified_tm_types: Vec<String> = verified_marks
+    let verified_tm_types: HashSet<String> = verified_marks
         .iter()
         .filter_map(|m| {
             m.get("trust_mark_type")
@@ -607,7 +607,7 @@ pub async fn run_collection_walk(
     redis::Cmd::set(format!("{STAGING_PREFIX}:trust_anchor"), trust_anchor)
         .query_async::<()>(conn)
         .await
-        .map_err(|e| anyhow!("failed to record staging trust_anchor: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("failed to record staging trust_anchor: {e}"))?;
 
     // Walk the tree
     debug!("Beginning recursive tree walk from {trust_anchor}");
@@ -622,7 +622,7 @@ pub async fn run_collection_walk(
     // `trust_mark_type` filter results.
     let tm_errors = ctx.tm_index_errors.load(Ordering::Relaxed);
     if tm_errors > 0 {
-        return Err(anyhow!(
+        return Err(anyhow::anyhow!(
             "{tm_errors} trust mark index write(s) failed; refusing to swap staging into the live collection"
         ));
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -3,11 +3,12 @@
 //! Walks a federation tree starting from a trust anchor, discovering all
 //! subordinate entities and storing their collection data in Redis.
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use josekit::jwk::JwkSet;
 use log::{debug, error, info, warn};
 use serde_json::{Map, Value};
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
@@ -43,6 +44,12 @@ struct CollectionWalkContext {
     trust_mark_issuers: Map<String, Value>,
     /// `trust_mark_owners` pinned by the Trust Anchor.
     trust_mark_owners: TrustMarkOwners,
+    /// Counts SADD failures on the `by_trustmark:{type}` / `trustmark_types`
+    /// staging keys, which drive the `/collection?trust_mark_type=...`
+    /// filter. A nonzero count means the index would be silently incomplete,
+    /// so `run_collection_walk` aborts the swap and surfaces the failure
+    /// instead of publishing inconsistent data.
+    tm_index_errors: AtomicU32,
 }
 
 /// Fetches authority subordinate statements and stores them in Redis.
@@ -407,17 +414,27 @@ async fn collection_tree_walking(
     // Index verified trust mark types so the trust_mark_type filter can
     // resolve entities by type. `trustmark_types` is a registry of every
     // indexed type, needed because by_trustmark keys are dynamic URLs.
+    // Errors here are critical: a missing index entry silently truncates
+    // `/collection?trust_mark_type=...` responses, so record any failure on
+    // the shared counter so `run_collection_walk` can abort the swap.
     for tm_type in &verified_tm_types {
-        let _: Result<(), _> = redis::Cmd::sadd(
+        if let Err(e) = redis::Cmd::sadd(
             format!("{STAGING_PREFIX}:by_trustmark:{tm_type}"),
             entity_id,
         )
-        .query_async(conn)
-        .await;
-        let _: Result<(), _> =
-            redis::Cmd::sadd(format!("{STAGING_PREFIX}:trustmark_types"), tm_type)
-                .query_async(conn)
-                .await;
+        .query_async::<()>(conn)
+        .await
+        {
+            error!("Failed to index trust mark type {tm_type} for {entity_id}: {e}");
+            ctx.tm_index_errors.fetch_add(1, Ordering::Relaxed);
+        }
+        if let Err(e) = redis::Cmd::sadd(format!("{STAGING_PREFIX}:trustmark_types"), tm_type)
+            .query_async::<()>(conn)
+            .await
+        {
+            error!("Failed to record trust mark type {tm_type} in registry: {e}");
+            ctx.tm_index_errors.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     // Also populate the existing inmor:op/rp/taia sets for backward compat
@@ -551,6 +568,7 @@ async fn build_walk_context(
         ta_keyset,
         trust_mark_issuers,
         trust_mark_owners,
+        tm_index_errors: AtomicU32::new(0),
     })
 }
 
@@ -583,10 +601,13 @@ pub async fn run_collection_walk(
     let _: Result<(), _> = redis::cmd("DEL").arg(&staging_keys).query_async(conn).await;
 
     // Record the Trust Anchor this collection was built from so /collection
-    // can validate the request `trust_anchor` parameter against it.
-    let _: Result<(), _> = redis::Cmd::set(format!("{STAGING_PREFIX}:trust_anchor"), trust_anchor)
-        .query_async(conn)
-        .await;
+    // can validate the request `trust_anchor` parameter against it. This
+    // write is required: without it the live collection would reject every
+    // request that supplies `trust_anchor=...` with `invalid_request`.
+    redis::Cmd::set(format!("{STAGING_PREFIX}:trust_anchor"), trust_anchor)
+        .query_async::<()>(conn)
+        .await
+        .map_err(|e| anyhow!("failed to record staging trust_anchor: {e}"))?;
 
     // Walk the tree
     debug!("Beginning recursive tree walk from {trust_anchor}");
@@ -595,6 +616,16 @@ pub async fn run_collection_walk(
 
     let entity_count = visited.len();
     info!("Walk complete: {entity_count} entities discovered");
+
+    // Abort before the atomic swap if any trust-mark index write failed --
+    // publishing the collection would yield silently incomplete
+    // `trust_mark_type` filter results.
+    let tm_errors = ctx.tm_index_errors.load(Ordering::Relaxed);
+    if tm_errors > 0 {
+        return Err(anyhow!(
+            "{tm_errors} trust mark index write(s) failed; refusing to swap staging into the live collection"
+        ));
+    }
 
     // Atomic swap: delete old live keys, rename staging -> live.
     debug!("Preparing atomic swap of staging -> live keys");

--- a/tests/test_inmor.py
+++ b/tests/test_inmor.py
@@ -102,10 +102,7 @@ def _accept_trust_mark(rdb: Redis, sub: str, trust_mark_obj: dict) -> None:
 
 
 def _resolve_payload(http_client: Client, port: int, sub: str) -> dict:
-    url = (
-        f"https://localhost:{port}/resolve"
-        f"?sub={sub}&trust_anchor={_TA_ENTITY_ID}"
-    )
+    url = f"https://localhost:{port}/resolve?sub={sub}&trust_anchor={_TA_ENTITY_ID}"
     resp = http_client.get(url)
     assert resp.status_code == 200, resp.text
     return _decode_jwt_payload(resp.text)
@@ -707,7 +704,7 @@ def test_historical_keys_revoked_field(loaddata: Redis, start_server: int, http_
             assert "reason" in revoked, "revoked object should contain reason"
             # Check reason is valid per spec
             assert revoked.get("reason") in ["unspecified", "compromised", "superseded"], (
-                f"revoked reason should be one of: unspecified, compromised, superseded"
+                "revoked reason should be one of: unspecified, compromised, superseded"
             )
 
 
@@ -1163,9 +1160,7 @@ def test_resolve_accepts_mark_with_valid_delegation(
     subject_id = fake_subject.entity_id
 
     owner_key = _make_owner_keypair()
-    delegation = _build_delegation_jwt(
-        owner_key, _OWNER_ENTITY_ID, _TA_ENTITY_ID, _TM_TYPE
-    )
+    delegation = _build_delegation_jwt(owner_key, _OWNER_ENTITY_ID, _TA_ENTITY_ID, _TM_TYPE)
     tm_obj = _build_trust_mark_with_delegation(subject_id, delegation)
     _build_subject(rdb, fake_subject, trust_marks=[tm_obj])
     _set_trust_mark_issuers(rdb, {_TM_TYPE: [_TA_ENTITY_ID]})
@@ -1193,9 +1188,7 @@ def test_resolve_accepts_mark_recognized_only_via_trust_mark_owners(
     subject_id = fake_subject.entity_id
 
     owner_key = _make_owner_keypair()
-    delegation = _build_delegation_jwt(
-        owner_key, _OWNER_ENTITY_ID, _TA_ENTITY_ID, _TM_TYPE
-    )
+    delegation = _build_delegation_jwt(owner_key, _OWNER_ENTITY_ID, _TA_ENTITY_ID, _TM_TYPE)
     tm_obj = _build_trust_mark_with_delegation(subject_id, delegation)
     _build_subject(rdb, fake_subject, trust_marks=[tm_obj])
     # trust_mark_issuers lists an unrelated type only -- _TM_TYPE is NOT in it.
@@ -1209,8 +1202,7 @@ def test_resolve_accepts_mark_recognized_only_via_trust_mark_owners(
     payload = _resolve_payload(http_client, port, subject_id)
     marks = payload.get("trust_marks")
     assert marks is not None and len(marks) == 1, (
-        "a type pinned only via trust_mark_owners must be recognised when the "
-        "delegation is valid"
+        "a type pinned only via trust_mark_owners must be recognised when the delegation is valid"
     )
 
 
@@ -1225,9 +1217,7 @@ def test_resolve_drops_mark_with_delegation_signed_by_wrong_key(
     real_owner_key = _make_owner_keypair()
     attacker_key = _make_owner_keypair()  # signs delegation but is NOT pinned
 
-    delegation = _build_delegation_jwt(
-        attacker_key, _OWNER_ENTITY_ID, _TA_ENTITY_ID, _TM_TYPE
-    )
+    delegation = _build_delegation_jwt(attacker_key, _OWNER_ENTITY_ID, _TA_ENTITY_ID, _TM_TYPE)
     tm_obj = _build_trust_mark_with_delegation(subject_id, delegation)
     _build_subject(rdb, fake_subject, trust_marks=[tm_obj])
     _set_trust_mark_issuers(rdb, {_TM_TYPE: [_TA_ENTITY_ID]})
@@ -1266,9 +1256,7 @@ def test_resolve_drops_mark_with_delegation_sub_mismatch(
     _accept_trust_mark(rdb, subject_id, tm_obj)
 
     payload = _resolve_payload(http_client, port, subject_id)
-    assert "trust_marks" not in payload, (
-        "delegation.sub != mark.iss must reject the mark"
-    )
+    assert "trust_marks" not in payload, "delegation.sub != mark.iss must reject the mark"
 
 
 def test_resolve_drops_mark_with_delegation_trust_mark_id_mismatch(
@@ -1399,3 +1387,258 @@ def test_resolve_falls_through_when_delegation_present_but_owner_unpinned(
     assert marks is not None and len(marks) == 1, (
         "unpinned-owner + delegation must fall through to the issuers gate"
     )
+
+
+# --- /collection endpoint -------------------------------------------------
+#
+# The Federation Entity Collection endpoint serves data the inmor-collection
+# CLI writes into `inmor:collection:*` Redis keys. These tests seed those keys
+# directly so the endpoint behaviour can be exercised without a full walk.
+
+_COLLECTION_TA = "https://collection-ta.example.com"
+
+
+def _b64url(value: str) -> str:
+    return base64.urlsafe_b64encode(value.encode()).decode().rstrip("=")
+
+
+def _reset_collection(rdb: Redis) -> None:
+    for key in rdb.keys("inmor:collection:*"):
+        rdb.delete(key)
+
+
+def _seed_collection(rdb: Redis, entities, trust_anchor: str = _COLLECTION_TA) -> None:
+    """Seed the `inmor:collection:*` keys for one collection.
+
+    `entities` is a list of dicts, each with `entity_id`, `entity_types`, and
+    optional `ui_infos` and `trust_mark_types` (the verified trust mark types
+    to index for that entity).
+    """
+    _reset_collection(rdb)
+    for ent in entities:
+        record = {"entity_id": ent["entity_id"], "entity_types": ent["entity_types"]}
+        if "ui_infos" in ent:
+            record["ui_infos"] = ent["ui_infos"]
+        rdb.hset("inmor:collection:entities", ent["entity_id"], json.dumps(record))
+        for etype in ent["entity_types"]:
+            rdb.sadd(f"inmor:collection:by_type:{etype}", ent["entity_id"])
+        rdb.zadd("inmor:collection:all_sorted", {ent["entity_id"]: 0})
+        for tmt in ent.get("trust_mark_types", []):
+            rdb.sadd(f"inmor:collection:by_trustmark:{tmt}", ent["entity_id"])
+            rdb.sadd("inmor:collection:trustmark_types", tmt)
+    rdb.set("inmor:collection:trust_anchor", trust_anchor)
+    rdb.set("inmor:collection:last_updated", int(time.time()))
+
+
+def test_collection_lists_seeded_entities(loaddata: Redis, start_server: int, http_client: Client):
+    "GET /collection returns every seeded entity, entity_id-sorted."
+    rdb = loaddata
+    port = start_server
+    _seed_collection(
+        rdb,
+        [
+            {
+                "entity_id": "https://a.example.com",
+                "entity_types": ["openid_provider", "federation_entity"],
+            },
+            {
+                "entity_id": "https://b.example.com",
+                "entity_types": ["openid_relying_party", "federation_entity"],
+            },
+        ],
+    )
+    resp = http_client.get(f"https://localhost:{port}/collection")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert [e["entity_id"] for e in data["entities"]] == [
+        "https://a.example.com",
+        "https://b.example.com",
+    ]
+    assert data["last_updated"] is not None
+    assert "next" not in data
+
+
+def test_collection_entity_type_filter_is_or(
+    loaddata: Redis, start_server: int, http_client: Client
+):
+    "Multiple entity_type parameters combine with OR (spec sec 3.3.1-2.3.1)."
+    rdb = loaddata
+    port = start_server
+    _seed_collection(
+        rdb,
+        [
+            {
+                "entity_id": "https://op.example.com",
+                "entity_types": ["openid_provider", "federation_entity"],
+            },
+            {
+                "entity_id": "https://rp.example.com",
+                "entity_types": ["openid_relying_party", "federation_entity"],
+            },
+            {
+                "entity_id": "https://as.example.com",
+                "entity_types": ["oauth_authorization_server", "federation_entity"],
+            },
+        ],
+    )
+    resp = http_client.get(
+        f"https://localhost:{port}/collection",
+        params=[
+            ("entity_type", "openid_provider"),
+            ("entity_type", "openid_relying_party"),
+        ],
+    )
+    assert resp.status_code == 200, resp.text
+    ids = sorted(e["entity_id"] for e in resp.json()["entities"])
+    assert ids == ["https://op.example.com", "https://rp.example.com"]
+
+
+def test_collection_trust_mark_type_filter_is_and(
+    loaddata: Redis, start_server: int, http_client: Client
+):
+    "Multiple trust_mark_type parameters combine with AND (spec sec 3.3.1-2.4.1)."
+    rdb = loaddata
+    port = start_server
+    tm_a = "https://example.com/tm/a"
+    tm_b = "https://example.com/tm/b"
+    _seed_collection(
+        rdb,
+        [
+            {
+                "entity_id": "https://x.example.com",
+                "entity_types": ["federation_entity"],
+                "trust_mark_types": [tm_a],
+            },
+            {
+                "entity_id": "https://y.example.com",
+                "entity_types": ["federation_entity"],
+                "trust_mark_types": [tm_a, tm_b],
+            },
+            {
+                "entity_id": "https://z.example.com",
+                "entity_types": ["federation_entity"],
+                "trust_mark_types": [tm_b],
+            },
+        ],
+    )
+    resp = http_client.get(
+        f"https://localhost:{port}/collection",
+        params=[("trust_mark_type", tm_a), ("trust_mark_type", tm_b)],
+    )
+    assert resp.status_code == 200, resp.text
+    assert [e["entity_id"] for e in resp.json()["entities"]] == ["https://y.example.com"]
+
+
+def test_collection_pagination_walks_pages(loaddata: Redis, start_server: int, http_client: Client):
+    "from/limit/next paginate the result set with consistent ordering."
+    rdb = loaddata
+    port = start_server
+    ids = [f"https://{c}.example.com" for c in "abcde"]
+    _seed_collection(rdb, [{"entity_id": i, "entity_types": ["federation_entity"]} for i in ids])
+
+    resp = http_client.get(f"https://localhost:{port}/collection", params={"limit": 2})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert [e["entity_id"] for e in data["entities"]] == ids[:2]
+    assert "next" in data
+
+    resp = http_client.get(
+        f"https://localhost:{port}/collection",
+        params={"limit": 2, "from": data["next"]},
+    )
+    data = resp.json()
+    assert [e["entity_id"] for e in data["entities"]] == ids[2:4]
+    assert "next" in data
+
+    resp = http_client.get(
+        f"https://localhost:{port}/collection",
+        params={"limit": 2, "from": data["next"]},
+    )
+    data = resp.json()
+    assert [e["entity_id"] for e in data["entities"]] == ids[4:]
+    assert "next" not in data
+
+
+def test_collection_trust_anchor_match_and_mismatch(
+    loaddata: Redis, start_server: int, http_client: Client
+):
+    "trust_anchor is accepted only when it matches the collected Trust Anchor."
+    rdb = loaddata
+    port = start_server
+    _seed_collection(
+        rdb,
+        [{"entity_id": "https://a.example.com", "entity_types": ["federation_entity"]}],
+        trust_anchor=_COLLECTION_TA,
+    )
+
+    resp = http_client.get(
+        f"https://localhost:{port}/collection", params={"trust_anchor": _COLLECTION_TA}
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = http_client.get(
+        f"https://localhost:{port}/collection",
+        params={"trust_anchor": "https://other-ta.example.com"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_request"
+
+
+def test_collection_query_filter(loaddata: Redis, start_server: int, http_client: Client):
+    "The query parameter substring-matches against entity records."
+    rdb = loaddata
+    port = start_server
+    _seed_collection(
+        rdb,
+        [
+            {
+                "entity_id": "https://university.example.com",
+                "entity_types": ["federation_entity"],
+            },
+            {
+                "entity_id": "https://company.example.org",
+                "entity_types": ["federation_entity"],
+            },
+        ],
+    )
+    resp = http_client.get(f"https://localhost:{port}/collection", params={"query": "university"})
+    assert resp.status_code == 200, resp.text
+    assert [e["entity_id"] for e in resp.json()["entities"]] == ["https://university.example.com"]
+
+
+def test_collection_unsupported_parameter(loaddata: Redis, start_server: int, http_client: Client):
+    "An unrecognised parameter is rejected with unsupported_parameter."
+    rdb = loaddata
+    port = start_server
+    _seed_collection(
+        rdb,
+        [{"entity_id": "https://a.example.com", "entity_types": ["federation_entity"]}],
+    )
+    resp = http_client.get(f"https://localhost:{port}/collection", params={"entity_claims": "x"})
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "unsupported_parameter"
+
+
+def test_collection_bad_cursor(loaddata: Redis, start_server: int, http_client: Client):
+    "An unknown cursor returns page_not_found; a malformed cursor invalid_request."
+    rdb = loaddata
+    port = start_server
+    _seed_collection(
+        rdb,
+        [{"entity_id": "https://a.example.com", "entity_types": ["federation_entity"]}],
+    )
+
+    # Well-formed cursor pointing at an entity the responder does not know.
+    resp = http_client.get(
+        f"https://localhost:{port}/collection",
+        params={"from": _b64url("https://nonexistent.example.com")},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"] == "page_not_found"
+
+    # A cursor that is not valid base64url.
+    resp = http_client.get(
+        f"https://localhost:{port}/collection", params={"from": "!!!not-base64!!!"}
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_request"

--- a/tests/test_inmor.py
+++ b/tests/test_inmor.py
@@ -1642,3 +1642,32 @@ def test_collection_bad_cursor(loaddata: Redis, start_server: int, http_client: 
     )
     assert resp.status_code == 400
     assert resp.json()["error"] == "invalid_request"
+
+
+def test_collection_next_cursor_anchors_on_returned_entity(
+    loaddata: Redis, start_server: int, http_client: Client
+):
+    "The `next` cursor must reference an entity actually returned in the page."
+    # If a candidate id has no record in `inmor:collection:entities` (because
+    # a Redis write was dropped or interrupted), the response should still
+    # produce a `next` cursor anchored on the last record actually returned,
+    # not on the missing id.
+    rdb = loaddata
+    port = start_server
+    ids = [f"https://{c}.example.com" for c in "abcd"]
+    _seed_collection(rdb, [{"entity_id": i, "entity_types": ["federation_entity"]} for i in ids])
+    # Remove the hash record for the 2nd id, keeping it in the sorted set
+    # and indexes so it still gets selected by the paginator.
+    rdb.hdel("inmor:collection:entities", "https://b.example.com")
+
+    resp = http_client.get(f"https://localhost:{port}/collection", params={"limit": 2})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    returned_ids = [e["entity_id"] for e in data["entities"]]
+    # `b` is gone from the hash so only `a` materializes in this window.
+    assert returned_ids == ["https://a.example.com"]
+    assert "next" in data
+    # The `next` cursor must decode to an entity that was actually returned,
+    # not to the dropped id.
+    decoded_next = base64.urlsafe_b64decode(data["next"] + "==").decode()
+    assert decoded_next == "https://a.example.com"

--- a/tests/test_inmor.py
+++ b/tests/test_inmor.py
@@ -1668,6 +1668,10 @@ def test_collection_next_cursor_anchors_on_returned_entity(
     assert returned_ids == ["https://a.example.com"]
     assert "next" in data
     # The `next` cursor must decode to an entity that was actually returned,
-    # not to the dropped id.
-    decoded_next = base64.urlsafe_b64decode(data["next"] + "==").decode()
+    # not to the dropped id. Restore padding dynamically -- a hard-coded
+    # "==" suffix would over-pad cursors whose length is already a multiple
+    # of 4 and raise "Incorrect padding".
+    cursor = data["next"]
+    cursor_padded = cursor + "=" * (-len(cursor) % 4)
+    decoded_next = base64.urlsafe_b64decode(cursor_padded).decode()
     assert decoded_next == "https://a.example.com"


### PR DESCRIPTION
 Bring the /collection endpoint to OpenID Federation Entity Collection 1.0
 Section 3 conformance. Previously it supported only the entity_type filter
 and returned the entire list on every call.

 Endpoint (src/lib.rs):
 - Add from/limit/next pagination. The cursor is a base64url-encoded entity_id; results stay ordered by entity_id for consistent paging.
 - Add trust_mark_type (AND), trust_anchor, and query filters alongside the existing entity_type (OR) filter. Filters of different kinds combine with AND.
 - Emit spec error codes: unsupported_parameter (400), invalid_request (400), and page_not_found (404).
 - Extract pure helpers (clamp_limit, encode_cursor, decode_cursor, query_matches) for unit testing.

 Trust mark verification (src/lib.rs):
 - Split verify_trust_marks_for_resolve into a reusable verify_trust_marks core plus a thin /resolve wrapper and a load_inmor_recognition_maps helper. /resolve behaviour is unchanged.

 Collection walker (src/tree.rs):
 - Build a CollectionWalkContext once from the walk-from Trust Anchor EC and verify every entity's trust marks against it, indexing only verified marks into inmor:collection:by_trustmark:{type}.
 - Record the walk-from Trust Anchor and a trustmark_types registry, and rework the atomic staging swap to handle the dynamic by_trustmark keys without using KEYS.