### PR TITLE
feat: add inmor-keygeneration binary for production key bootstrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/bin/inmor/main.rs"
 name = "inmor-collection"
 path = "src/bin/inmor-collection/main.rs"
 
+[[bin]]
+name = "inmor-keygeneration"
+path = "src/bin/inmor-keygeneration/main.rs"
+
 [dependencies]
 actix-web = { version = "4.10.2", features = ["rustls-0_23"] }
 josekit = "0.10.3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,11 @@ RUN --mount=type=bind,source=Cargo.toml,target=/app/Cargo.toml \
 
 ##### Production image
 FROM debian:13-slim
+# Pin the uid/gid so deployments and docs can rely on a fixed value
+# (operators must own key files such as private.json by this uid).
 RUN <<EOT
-groupadd -r app
-useradd -r -d /app -g app -N app
+groupadd -r -g 999 app
+useradd -r -u 999 -d /app -g app -N app
 EOT
 
 RUN <<EOT

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ EOT
 # Copy from the build container
 COPY --from=build --chown=app:app /app/target/release/inmor /app/
 COPY --from=build --chown=app:app /app/target/release/inmor-collection /app/
+COPY --from=build --chown=app:app /app/target/release/inmor-keygeneration /app/
 COPY --chown=app:app templates/ /app/templates/
 
 USER app

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -714,11 +714,11 @@ starting the server for the first time.
 Ownership matters
 ^^^^^^^^^^^^^^^^^
 
-The TA container runs as the image's unprivileged ``app`` user, **uid 999**,
-and ``private.json`` is created with mode ``0600`` (readable only by its
-owner). For the TA to read its signing key, ``private.json`` must be owned by
-uid 999. The public key files are written ``0644``, so their ownership does
-not matter.
+The TA container runs as the image's unprivileged ``app`` user, whose uid and
+gid are pinned to **999** in the ``Dockerfile``. ``private.json`` is created
+with mode ``0600`` (readable only by its owner), so for the TA to read its
+signing key, ``private.json`` must be owned by uid 999. The public key files
+are written ``0644``, so their ownership does not matter.
 
 The simplest way to satisfy this is to generate the keys *as* uid 999, which
 is the image's default user. Create an output directory that uid 999 can write

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -709,16 +709,37 @@ The Trust Anchor signs every entity statement and trust mark with the private
 key in ``private.json`` and publishes the matching public keys from
 ``publickeys/``. The ``inmor-keygeneration`` binary, bundled in the TA image,
 creates such a keypair without needing this source tree — run it once before
-starting the server for the first time::
+starting the server for the first time.
 
-   docker run --rm -v ./:/data --user "$(id -u):$(id -g)" \
-     docker.sunet.se/inmor:0.4.0 \
+Ownership matters
+^^^^^^^^^^^^^^^^^
+
+The TA container runs as the image's unprivileged ``app`` user, **uid 999**,
+and ``private.json`` is created with mode ``0600`` (readable only by its
+owner). For the TA to read its signing key, ``private.json`` must be owned by
+uid 999. The public key files are written ``0644``, so their ownership does
+not matter.
+
+The simplest way to satisfy this is to generate the keys *as* uid 999, which
+is the image's default user. Create an output directory that uid 999 can write
+to, then run the generator::
+
+   mkdir -p keys
+   sudo chown 999:999 keys
+
+   docker run --rm -v ./keys:/data docker.sunet.se/inmor:0.4.0 \
      /app/inmor-keygeneration --type=RS256 --output=/data
 
-This writes two files into the mounted directory:
+This writes two files into the ``keys`` directory:
 
-* ``private.json`` — the signing key, created with file mode ``0600``
-* ``publickeys/{kid}.json`` — the public JWK, named by its key ID
+* ``private.json`` — the signing key, mode ``0600``, owned by uid 999
+* ``publickeys/{kid}.json`` — the public JWK, mode ``0644``, named by its key ID
+
+Mount them into the ``ta`` service read-only (see `Volume Mounts`_)::
+
+   volumes:
+     - ./keys/private.json:/app/private.json:ro
+     - ./keys/publickeys:/app/publickeys:ro
 
 The ``--type`` option selects the key algorithm, following
 `RFC 9864 Section 2 <https://www.rfc-editor.org/rfc/rfc9864.html#section-2>`_:
@@ -749,13 +770,12 @@ If ``private.json`` already exists, the command refuses to overwrite it; pass
 
 .. note::
 
-   ``--user "$(id -u):$(id -g)"`` runs the generator as the invoking host user
-   so the generated files are owned by you. Without it the container's ``app``
-   user typically cannot write to a host directory owned by another user, and
-   the command fails with a permission error.
-
-Mount the resulting ``private.json`` and ``publickeys/`` into the ``ta``
-service as shown in `Volume Mounts`_.
+   If you cannot ``chown`` a directory to uid 999 (for example on a host where
+   you lack root), generate the files as your own host user by adding
+   ``--user "$(id -u):$(id -g)"`` to the ``docker run`` command. The key files
+   are then owned by your host uid, so you must also add a matching ``user:``
+   entry to the ``ta`` service in the compose file so the TA container runs
+   under the same uid and can read ``private.json``.
 
 Initialization Workflow
 -----------------------

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -700,6 +700,63 @@ Admin Portal (admin)
    * - ``HISTORICAL_KEYS_DIR``
      - Path to historical keys (default: ``./historical_keys``)
 
+.. _generating-the-signing-key:
+
+Generating the Signing Key
+--------------------------
+
+The Trust Anchor signs every entity statement and trust mark with the private
+key in ``private.json`` and publishes the matching public keys from
+``publickeys/``. The ``inmor-keygeneration`` binary, bundled in the TA image,
+creates such a keypair without needing this source tree — run it once before
+starting the server for the first time::
+
+   docker run --rm -v ./:/data --user "$(id -u):$(id -g)" \
+     docker.sunet.se/inmor:0.4.0 \
+     /app/inmor-keygeneration --type=RS256 --output=/data
+
+This writes two files into the mounted directory:
+
+* ``private.json`` — the signing key, created with file mode ``0600``
+* ``publickeys/{kid}.json`` — the public JWK, named by its key ID
+
+The ``--type`` option selects the key algorithm, following
+`RFC 9864 Section 2 <https://www.rfc-editor.org/rfc/rfc9864.html#section-2>`_:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - ``--type``
+     - Key
+   * - ``RS256``
+     - RSA 2048-bit, RSASSA-PKCS1-v1_5
+   * - ``PS256``
+     - RSA 2048-bit, RSASSA-PSS
+   * - ``ES256`` / ``ES384`` / ``ES512``
+     - EC, curves P-256 / P-384 / P-521
+   * - ``Ed25519`` / ``Ed448``
+     - Edwards curve (OKP)
+
+If ``private.json`` already exists, the command refuses to overwrite it; pass
+``--force`` to replace it.
+
+.. warning::
+
+   Overwriting ``private.json`` invalidates every entity statement and trust
+   mark the Trust Anchor has already signed. Generate a new signing key only
+   for a fresh deployment or a deliberate key rotation.
+
+.. note::
+
+   ``--user "$(id -u):$(id -g)"`` runs the generator as the invoking host user
+   so the generated files are owned by you. Without it the container's ``app``
+   user typically cannot write to a host directory owned by another user, and
+   the command fails with a permission error.
+
+Mount the resulting ``private.json`` and ``publickeys/`` into the ``ta``
+service as shown in `Volume Mounts`_.
+
 Initialization Workflow
 -----------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -108,6 +108,10 @@ Each key is stored as a JWK JSON file with the key ID (kid) as the thumbprint.
    Regenerating keys will invalidate all existing entity statements and trust marks.
    Make sure to backup and properly rotate keys in production.
 
+For a production server that only has the Docker image and not this source
+tree, generate the signing key with the bundled ``inmor-keygeneration``
+binary instead. See :ref:`generating-the-signing-key` in the deployment guide.
+
 Directory Structure
 -------------------
 

--- a/justfile
+++ b/justfile
@@ -49,8 +49,8 @@ lint: lint-rust lint-python
 
 # To run inmor tests
 test-ta *ARGS:
-  # Run Rust unit tests first
-  cargo test --lib
+  # Run Rust unit tests first (library and binary targets)
+  cargo test --lib --bins
   # We have integration tests for the inmor rust binary
   uv run pytest -vvv {{ARGS}}
 

--- a/src/bin/inmor-keygeneration/main.rs
+++ b/src/bin/inmor-keygeneration/main.rs
@@ -183,25 +183,58 @@ fn already_exists_error(path: &Path) -> anyhow::Error {
     )
 }
 
-/// Write `contents` to `path` with an explicit file mode.
+/// Atomically write `contents` to `path` with an exact file mode.
 ///
-/// When `overwrite` is false the file is created atomically (`create_new`), so
-/// the call fails with `AlreadyExists` instead of clobbering a file that
-/// appeared after an earlier existence check — closing the TOCTOU gap. The
-/// mode is also reapplied after writing so it is enforced when overwriting an
-/// existing file (where `OpenOptions::mode` has no effect).
+/// The data is written to a freshly created temporary file in the same
+/// directory, has its mode forced via the file descriptor (`fchmod`, so the
+/// umask cannot widen or narrow it), is fsynced, and is only then moved into
+/// place. Consequences:
+///
+/// * A crash or short write never leaves a truncated key file at `path` — the
+///   incomplete data only ever exists under the temporary name.
+/// * The move targets the path entry itself, never a symlink's target, so it
+///   cannot be tricked into clobbering an arbitrary file.
+/// * When `overwrite` is false the move uses `hard_link`, which fails with
+///   `AlreadyExists` if `path` already exists — an atomic no-clobber guarantee
+///   with no time-of-check/time-of-use gap.
 fn write_file(path: &Path, contents: &str, mode: u32, overwrite: bool) -> io::Result<()> {
-    let mut options = fs::OpenOptions::new();
-    options.write(true).mode(mode);
-    if overwrite {
-        options.create(true).truncate(true);
-    } else {
-        options.create_new(true);
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+    let parent = parent.unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "output path has no file name")
+    })?;
+    let tmp_path = parent.join(format!(
+        ".{}.{}.tmp",
+        file_name.to_string_lossy(),
+        std::process::id()
+    ));
+
+    // Create the temp file fresh (create_new => never a planted symlink) and
+    // force the exact mode through the descriptor, defeating the umask.
+    let staged = (|| -> io::Result<()> {
+        let mut tmp = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(mode)
+            .open(&tmp_path)?;
+        tmp.set_permissions(fs::Permissions::from_mode(mode))?;
+        tmp.write_all(contents.as_bytes())?;
+        tmp.sync_all()
+    })();
+    if let Err(err) = staged {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(err);
     }
-    let mut file = options.open(path)?;
-    file.write_all(contents.as_bytes())?;
-    fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
-    Ok(())
+
+    // Move the staged file into place. `rename` and `hard_link` both act on
+    // the path entry itself and never follow a symlink at the destination.
+    let moved = if overwrite {
+        fs::rename(&tmp_path, path)
+    } else {
+        fs::hard_link(&tmp_path, path)
+    };
+    let _ = fs::remove_file(&tmp_path);
+    moved
 }
 
 fn run() -> Result<()> {
@@ -428,11 +461,46 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(fs::read_to_string(&path).unwrap(), "first");
 
-        // With overwrite the file is replaced and the mode is reapplied.
+        // With overwrite the file is replaced and the exact mode is enforced.
         write_file(&path, "third", 0o600, true).expect("force overwrite");
         assert_eq!(fs::read_to_string(&path).unwrap(), "third");
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
+
+        // No temporary files are left behind.
+        let leftovers: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "stray temp files: {leftovers:?}");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Writing through a path that is a symlink must replace the symlink
+    /// itself, never write through it to clobber the symlink's target.
+    #[test]
+    fn write_file_does_not_follow_symlinks() {
+        let dir = std::env::temp_dir().join(format!("inmor-keygen-symlink-{}", std::process::id()));
+        fs::create_dir_all(&dir).expect("temp dir");
+
+        let target = dir.join("sensitive-target");
+        fs::write(&target, "must-not-change").expect("write target");
+        let link = dir.join("private.json");
+        let _ = fs::remove_file(&link);
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        write_file(&link, "new-key", 0o600, true).expect("overwrite via symlink path");
+
+        // The symlink's target file is untouched.
+        assert_eq!(fs::read_to_string(&target).unwrap(), "must-not-change");
+        // The path is now a regular file holding the new content.
+        assert!(
+            fs::symlink_metadata(&link).unwrap().file_type().is_file(),
+            "path should be a regular file, not a symlink"
+        );
+        assert_eq!(fs::read_to_string(&link).unwrap(), "new-key");
 
         fs::remove_dir_all(&dir).ok();
     }

--- a/src/bin/inmor-keygeneration/main.rs
+++ b/src/bin/inmor-keygeneration/main.rs
@@ -1,0 +1,396 @@
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::{Context, Result, bail};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use clap::{Parser, ValueEnum};
+use josekit::jwk::Jwk;
+use josekit::jwk::KeyPair;
+use josekit::jwk::alg::ec::{EcCurve, EcKeyPair};
+use josekit::jwk::alg::ed::{EdCurve, EdKeyPair};
+use josekit::jwk::alg::rsa::RsaKeyPair;
+use sha2::{Digest, Sha256};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "inmor-keygeneration",
+    version(env!("CARGO_PKG_VERSION")),
+    about = "Generates a Trust Anchor signing keypair (private.json + public JWK)"
+)]
+struct Cli {
+    #[arg(
+        long = "type",
+        value_enum,
+        ignore_case = true,
+        help = "Key/algorithm type to generate"
+    )]
+    key_type: KeyType,
+
+    #[arg(
+        long = "output",
+        value_name = "DIR",
+        default_value = ".",
+        help = "Directory to write private.json and publickeys/{kid}.json into"
+    )]
+    output: PathBuf,
+
+    #[arg(long = "force", help = "Overwrite an existing private.json")]
+    force: bool,
+}
+
+/// Supported signing key types, named after their JWK `alg` value.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum KeyType {
+    #[value(name = "RS256")]
+    Rs256,
+    #[value(name = "PS256")]
+    Ps256,
+    #[value(name = "ES256")]
+    Es256,
+    #[value(name = "ES384")]
+    Es384,
+    #[value(name = "ES512")]
+    Es512,
+    #[value(name = "Ed25519")]
+    Ed25519,
+    #[value(name = "Ed448")]
+    Ed448,
+}
+
+impl KeyType {
+    /// The JWK `alg` value stamped onto the generated key.
+    fn alg(self) -> &'static str {
+        match self {
+            KeyType::Rs256 => "RS256",
+            KeyType::Ps256 => "PS256",
+            KeyType::Es256 => "ES256",
+            KeyType::Es384 => "ES384",
+            KeyType::Es512 => "ES512",
+            KeyType::Ed25519 => "Ed25519",
+            KeyType::Ed448 => "Ed448",
+        }
+    }
+}
+
+/// Generate a fresh keypair and return its `(private_jwk, public_jwk)`.
+///
+/// The private JWK is a complete key pair (private + public members), matching
+/// the existing on-disk convention. RS256 and PS256 share identical RSA key
+/// material; only the `alg` stamped on the JWK distinguishes them, so both
+/// come from the same RSA generator.
+fn generate_keypair(key_type: KeyType) -> Result<(Jwk, Jwk)> {
+    let pair: (Jwk, Jwk) = match key_type {
+        KeyType::Rs256 | KeyType::Ps256 => {
+            let kp = RsaKeyPair::generate(2048).context("RSA key generation failed")?;
+            (kp.to_jwk_key_pair(), kp.to_jwk_public_key())
+        }
+        KeyType::Es256 => {
+            let kp =
+                EcKeyPair::generate(EcCurve::P256).context("EC P-256 key generation failed")?;
+            (kp.to_jwk_key_pair(), kp.to_jwk_public_key())
+        }
+        KeyType::Es384 => {
+            let kp =
+                EcKeyPair::generate(EcCurve::P384).context("EC P-384 key generation failed")?;
+            (kp.to_jwk_key_pair(), kp.to_jwk_public_key())
+        }
+        KeyType::Es512 => {
+            let kp =
+                EcKeyPair::generate(EcCurve::P521).context("EC P-521 key generation failed")?;
+            (kp.to_jwk_key_pair(), kp.to_jwk_public_key())
+        }
+        KeyType::Ed25519 => {
+            let kp =
+                EdKeyPair::generate(EdCurve::Ed25519).context("Ed25519 key generation failed")?;
+            (kp.to_jwk_key_pair(), kp.to_jwk_public_key())
+        }
+        KeyType::Ed448 => {
+            let kp = EdKeyPair::generate(EdCurve::Ed448).context("Ed448 key generation failed")?;
+            (kp.to_jwk_key_pair(), kp.to_jwk_public_key())
+        }
+    };
+    Ok(pair)
+}
+
+/// Return a complete private JWK that contains every member of the public JWK.
+///
+/// josekit's `to_jwk_key_pair()` returns full RSA and EC keys, but omits the
+/// public `x` member for OKP (Ed) keys. Filling in any missing public member
+/// keeps `private.json` a self-contained, RFC-conformant key pair.
+fn complete_private_jwk(private: &Jwk, public: &Jwk) -> Result<Jwk> {
+    let mut map = private.as_ref().clone();
+    for (key, value) in public.as_ref() {
+        map.entry(key.clone()).or_insert_with(|| value.clone());
+    }
+    Jwk::from_map(map).context("failed to assemble complete private JWK")
+}
+
+/// Compute the RFC 7638 JWK thumbprint (SHA-256, base64url, no padding).
+///
+/// josekit does not expose this, so it is built here from the required
+/// members in lexicographic order. Those member values are base64url strings
+/// (or fixed curve names) with no JSON-escapable characters, so the canonical
+/// JSON is assembled directly.
+fn jwk_thumbprint(jwk: &Jwk) -> Result<String> {
+    let kty = jwk.key_type();
+    let canonical = match kty {
+        "RSA" => {
+            let e = required_member(jwk, "e")?;
+            let n = required_member(jwk, "n")?;
+            format!(r#"{{"e":"{e}","kty":"RSA","n":"{n}"}}"#)
+        }
+        "EC" => {
+            let crv = required_member(jwk, "crv")?;
+            let x = required_member(jwk, "x")?;
+            let y = required_member(jwk, "y")?;
+            format!(r#"{{"crv":"{crv}","kty":"EC","x":"{x}","y":"{y}"}}"#)
+        }
+        "OKP" => {
+            let crv = required_member(jwk, "crv")?;
+            let x = required_member(jwk, "x")?;
+            format!(r#"{{"crv":"{crv}","kty":"OKP","x":"{x}"}}"#)
+        }
+        other => bail!("cannot compute thumbprint for unsupported key type '{other}'"),
+    };
+    Ok(URL_SAFE_NO_PAD.encode(Sha256::digest(canonical.as_bytes())))
+}
+
+/// Read a required string member from a JWK.
+fn required_member(jwk: &Jwk, key: &str) -> Result<String> {
+    jwk.parameter(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+        .with_context(|| format!("generated JWK is missing required member '{key}'"))
+}
+
+/// Serialize a JWK to pretty-printed JSON with a trailing newline.
+fn jwk_to_json(jwk: &Jwk) -> Result<String> {
+    let mut json = serde_json::to_string_pretty(jwk.as_ref())?;
+    json.push('\n');
+    Ok(json)
+}
+
+/// Write `private.json` with mode 0600.
+fn write_private_key(path: &Path, jwk: &Jwk) -> Result<()> {
+    let json = jwk_to_json(jwk)?;
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    file.write_all(json.as_bytes())?;
+    // `.mode()` only applies on creation; enforce 0600 on overwrite too.
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("failed to set permissions on {}", path.display()))?;
+    Ok(())
+}
+
+/// Write a public key JWK to `publickeys/{kid}.json` with default permissions.
+fn write_public_key(path: &Path, jwk: &Jwk) -> Result<()> {
+    fs::write(path, jwk_to_json(jwk)?)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+fn run() -> Result<()> {
+    let cli = Cli::parse();
+    let alg = cli.key_type.alg();
+
+    let private_path = cli.output.join("private.json");
+    if private_path.exists() && !cli.force {
+        bail!(
+            "{} already exists.\n  Re-run with --force to overwrite (this invalidates all \
+             entity statements and trust marks already signed by the Trust Anchor).",
+            private_path.display()
+        );
+    }
+
+    let (private_pair, mut public_jwk) = generate_keypair(cli.key_type)?;
+    let mut private_jwk = complete_private_jwk(&private_pair, &public_jwk)?;
+    let kid = jwk_thumbprint(&public_jwk)?;
+
+    for jwk in [&mut private_jwk, &mut public_jwk] {
+        jwk.set_key_use("sig");
+        jwk.set_algorithm(alg);
+        jwk.set_key_id(kid.as_str());
+    }
+
+    let publickeys_dir = cli.output.join("publickeys");
+    fs::create_dir_all(&cli.output)
+        .with_context(|| format!("failed to create {}", cli.output.display()))?;
+    fs::create_dir_all(&publickeys_dir)
+        .with_context(|| format!("failed to create {}", publickeys_dir.display()))?;
+
+    let public_path = publickeys_dir.join(format!("{kid}.json"));
+
+    write_private_key(&private_path, &private_jwk)?;
+    write_public_key(&public_path, &public_jwk)?;
+
+    println!("Generated {alg} key with KID: {kid}");
+    println!("  private key: {}", private_path.display());
+    println!("  public key:  {}", public_path.display());
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("error: {err:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use josekit::jws::{
+        self, ES256, ES384, ES512, EdDSA, JwsHeader, JwsSigner, JwsVerifier, PS256, RS256,
+    };
+
+    /// RFC 7638 Section 3.1 worked example.
+    #[test]
+    fn rfc7638_thumbprint_known_answer() {
+        let jwk_json = r#"{
+            "kty":"RSA",
+            "n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+            "e":"AQAB",
+            "alg":"RS256",
+            "kid":"2011-04-29"
+        }"#;
+        let jwk = Jwk::from_bytes(jwk_json.as_bytes()).expect("valid JWK");
+        assert_eq!(
+            jwk_thumbprint(&jwk).expect("thumbprint"),
+            "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
+        );
+    }
+
+    /// Generate a key, stamp it, and return both JWKs the way `run()` does.
+    fn generate_stamped(key_type: KeyType) -> (Jwk, Jwk, String) {
+        let (private_pair, mut public_jwk) = generate_keypair(key_type).expect("generation");
+        let mut private_jwk =
+            complete_private_jwk(&private_pair, &public_jwk).expect("complete private JWK");
+        let kid = jwk_thumbprint(&public_jwk).expect("thumbprint");
+        for jwk in [&mut private_jwk, &mut public_jwk] {
+            jwk.set_key_use("sig");
+            jwk.set_algorithm(key_type.alg());
+            jwk.set_key_id(kid.as_str());
+        }
+        (private_jwk, public_jwk, kid)
+    }
+
+    fn all_types() -> [KeyType; 7] {
+        [
+            KeyType::Rs256,
+            KeyType::Ps256,
+            KeyType::Es256,
+            KeyType::Es384,
+            KeyType::Es512,
+            KeyType::Ed25519,
+            KeyType::Ed448,
+        ]
+    }
+
+    #[test]
+    fn generated_keys_have_expected_fields() {
+        for key_type in all_types() {
+            let (private_jwk, public_jwk, kid) = generate_stamped(key_type);
+
+            for jwk in [&private_jwk, &public_jwk] {
+                assert_eq!(jwk.algorithm(), Some(key_type.alg()), "{key_type:?} alg");
+                assert_eq!(jwk.key_use(), Some("sig"), "{key_type:?} use");
+                assert_eq!(jwk.key_id(), Some(kid.as_str()), "{key_type:?} kid");
+            }
+
+            // The kid must equal the thumbprint of the public key.
+            assert_eq!(
+                jwk_thumbprint(&public_jwk).unwrap(),
+                kid,
+                "{key_type:?} kid"
+            );
+
+            // Private material is present in the private JWK only.
+            assert!(
+                private_jwk.parameter("d").is_some(),
+                "{key_type:?} private key missing 'd'"
+            );
+            assert!(
+                public_jwk.parameter("d").is_none(),
+                "{key_type:?} public key leaked 'd'"
+            );
+
+            // The private JWK is a complete superset of the public JWK.
+            for member in ["kty", "n", "e", "crv", "x", "y"] {
+                if public_jwk.parameter(member).is_some() {
+                    assert_eq!(
+                        private_jwk.parameter(member),
+                        public_jwk.parameter(member),
+                        "{key_type:?} private key missing public member '{member}'"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Mirror `create_signed_jwt` in src/lib.rs: inmor stores Ed keys with
+    /// `alg` "Ed25519"/"Ed448", but josekit's EdDSA signer requires "EdDSA".
+    fn normalize_for_josekit(jwk: &Jwk) -> Jwk {
+        match jwk.algorithm() {
+            Some("Ed25519") | Some("Ed448") => {
+                let mut map = jwk.as_ref().clone();
+                map.insert("alg".to_string(), serde_json::json!("EdDSA"));
+                Jwk::from_map(map).expect("valid JWK")
+            }
+            _ => jwk.clone(),
+        }
+    }
+
+    fn signer_for(key_type: KeyType, jwk: &Jwk) -> Box<dyn JwsSigner> {
+        let jwk = normalize_for_josekit(jwk);
+        match key_type {
+            KeyType::Rs256 => Box::new(RS256.signer_from_jwk(&jwk).unwrap()),
+            KeyType::Ps256 => Box::new(PS256.signer_from_jwk(&jwk).unwrap()),
+            KeyType::Es256 => Box::new(ES256.signer_from_jwk(&jwk).unwrap()),
+            KeyType::Es384 => Box::new(ES384.signer_from_jwk(&jwk).unwrap()),
+            KeyType::Es512 => Box::new(ES512.signer_from_jwk(&jwk).unwrap()),
+            KeyType::Ed25519 | KeyType::Ed448 => Box::new(EdDSA.signer_from_jwk(&jwk).unwrap()),
+        }
+    }
+
+    fn verifier_for(key_type: KeyType, jwk: &Jwk) -> Box<dyn JwsVerifier> {
+        let jwk = normalize_for_josekit(jwk);
+        match key_type {
+            KeyType::Rs256 => Box::new(RS256.verifier_from_jwk(&jwk).unwrap()),
+            KeyType::Ps256 => Box::new(PS256.verifier_from_jwk(&jwk).unwrap()),
+            KeyType::Es256 => Box::new(ES256.verifier_from_jwk(&jwk).unwrap()),
+            KeyType::Es384 => Box::new(ES384.verifier_from_jwk(&jwk).unwrap()),
+            KeyType::Es512 => Box::new(ES512.verifier_from_jwk(&jwk).unwrap()),
+            KeyType::Ed25519 | KeyType::Ed448 => Box::new(EdDSA.verifier_from_jwk(&jwk).unwrap()),
+        }
+    }
+
+    /// Every generated keypair must sign and verify a round-trip, proving the
+    /// key works for the Trust Anchor's JWT signing path.
+    #[test]
+    fn generated_keys_sign_and_verify() {
+        let payload = b"inmor-keygeneration round-trip";
+        for key_type in all_types() {
+            let (private_jwk, public_jwk, _) = generate_stamped(key_type);
+            let signer = signer_for(key_type, &private_jwk);
+            let verifier = verifier_for(key_type, &public_jwk);
+
+            let compact = jws::serialize_compact(payload, &JwsHeader::new(), &*signer)
+                .unwrap_or_else(|e| panic!("{key_type:?} sign failed: {e}"));
+            let (out, _) = jws::deserialize_compact(&compact, &*verifier)
+                .unwrap_or_else(|e| panic!("{key_type:?} verify failed: {e}"));
+            assert_eq!(out, payload, "{key_type:?} round-trip payload mismatch");
+        }
+    }
+}

--- a/src/bin/inmor-keygeneration/main.rs
+++ b/src/bin/inmor-keygeneration/main.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::Write;
+use std::io::{self, Write};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -174,27 +174,33 @@ fn jwk_to_json(jwk: &Jwk) -> Result<String> {
     Ok(json)
 }
 
-/// Write `private.json` with mode 0600.
-fn write_private_key(path: &Path, jwk: &Jwk) -> Result<()> {
-    let json = jwk_to_json(jwk)?;
-    let mut file = fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .mode(0o600)
-        .open(path)
-        .with_context(|| format!("failed to write {}", path.display()))?;
-    file.write_all(json.as_bytes())?;
-    // `.mode()` only applies on creation; enforce 0600 on overwrite too.
-    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
-        .with_context(|| format!("failed to set permissions on {}", path.display()))?;
-    Ok(())
+/// The error shown when `private.json` already exists and `--force` was not given.
+fn already_exists_error(path: &Path) -> anyhow::Error {
+    anyhow::anyhow!(
+        "{} already exists.\n  Re-run with --force to overwrite (this invalidates all \
+         entity statements and trust marks already signed by the Trust Anchor).",
+        path.display()
+    )
 }
 
-/// Write a public key JWK to `publickeys/{kid}.json` with default permissions.
-fn write_public_key(path: &Path, jwk: &Jwk) -> Result<()> {
-    fs::write(path, jwk_to_json(jwk)?)
-        .with_context(|| format!("failed to write {}", path.display()))?;
+/// Write `contents` to `path` with an explicit file mode.
+///
+/// When `overwrite` is false the file is created atomically (`create_new`), so
+/// the call fails with `AlreadyExists` instead of clobbering a file that
+/// appeared after an earlier existence check — closing the TOCTOU gap. The
+/// mode is also reapplied after writing so it is enforced when overwriting an
+/// existing file (where `OpenOptions::mode` has no effect).
+fn write_file(path: &Path, contents: &str, mode: u32, overwrite: bool) -> io::Result<()> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).mode(mode);
+    if overwrite {
+        options.create(true).truncate(true);
+    } else {
+        options.create_new(true);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(contents.as_bytes())?;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
     Ok(())
 }
 
@@ -203,12 +209,10 @@ fn run() -> Result<()> {
     let alg = cli.key_type.alg();
 
     let private_path = cli.output.join("private.json");
+    // Fast, friendly check for the common case. `write_file` below still uses
+    // `create_new`, so a file appearing after this check cannot be clobbered.
     if private_path.exists() && !cli.force {
-        bail!(
-            "{} already exists.\n  Re-run with --force to overwrite (this invalidates all \
-             entity statements and trust marks already signed by the Trust Anchor).",
-            private_path.display()
-        );
+        return Err(already_exists_error(&private_path));
     }
 
     let (private_pair, mut public_jwk) = generate_keypair(cli.key_type)?;
@@ -229,8 +233,19 @@ fn run() -> Result<()> {
 
     let public_path = publickeys_dir.join(format!("{kid}.json"));
 
-    write_private_key(&private_path, &private_jwk)?;
-    write_public_key(&public_path, &public_jwk)?;
+    // Write the public key first: it is content-addressed by `kid` and safe to
+    // (re)write, so if the private-key write fails the state stays recoverable
+    // (no private.json without its public half).
+    write_file(&public_path, &jwk_to_json(&public_jwk)?, 0o644, true)
+        .with_context(|| format!("failed to write {}", public_path.display()))?;
+
+    if let Err(err) = write_file(&private_path, &jwk_to_json(&private_jwk)?, 0o600, cli.force) {
+        return Err(if err.kind() == io::ErrorKind::AlreadyExists {
+            already_exists_error(&private_path)
+        } else {
+            anyhow::Error::new(err).context(format!("failed to write {}", private_path.display()))
+        });
+    }
 
     println!("Generated {alg} key with KID: {kid}");
     println!("  private key: {}", private_path.display());
@@ -392,5 +407,33 @@ mod tests {
                 .unwrap_or_else(|e| panic!("{key_type:?} verify failed: {e}"));
             assert_eq!(out, payload, "{key_type:?} round-trip payload mismatch");
         }
+    }
+
+    /// `write_file` must not clobber an existing file unless overwrite is set,
+    /// and must enforce the requested mode.
+    #[test]
+    fn write_file_respects_overwrite_and_mode() {
+        let dir = std::env::temp_dir().join(format!("inmor-keygen-write-{}", std::process::id()));
+        fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("private.json");
+        let _ = fs::remove_file(&path);
+
+        // First write creates the file.
+        write_file(&path, "first", 0o600, false).expect("initial write");
+        assert_eq!(fs::read_to_string(&path).unwrap(), "first");
+
+        // Without overwrite a second write fails atomically and leaves the
+        // original contents intact (no truncation).
+        let err = write_file(&path, "second", 0o600, false).expect_err("must refuse overwrite");
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read_to_string(&path).unwrap(), "first");
+
+        // With overwrite the file is replaced and the mode is reapplied.
+        write_file(&path, "third", 0o600, true).expect("force overwrite");
+        assert_eq!(fs::read_to_string(&path).unwrap(), "third");
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+
+        fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
Adds a third Rust binary, inmor-keygeneration, baked into the TA image. It lets an operator generate a Trust Anchor signing keypair from just the published Docker image, with no source tree, jwcrypto, or uv required:

  docker run --rm -v ./:/data --user "$(id -u):$(id -g)" \
    docker.sunet.se/inmor:0.4.0 \
    /app/inmor-keygeneration --type=RS256 --output=/data

The binary takes --type (RS256, PS256, ES256, ES384, ES512, Ed25519, Ed448) and --output (a base directory), and writes private.json (mode 0600) plus publickeys/{kid}.json (mode 0644), creating directories as needed. The key id is the RFC 7638 JWK thumbprint. It refuses to overwrite an existing private.json unless --force is given, since overwriting the signing key invalidates every entity statement and trust mark already signed.