### PR TITLE
build(deps): pin uv exclude-newer to a fixed UTC timestamp

### DIFF
--- a/admin/pyproject.toml
+++ b/admin/pyproject.toml
@@ -49,6 +49,14 @@ dependencies = [
 [project.urls]
 Home = "https://github.com/SUNET/inmor"
 
+[tool.uv]
+# Supply-chain cooling window: never resolve distributions published after
+# this date. A fixed UTC timestamp (not a rolling span, and not a bare
+# date which uv resolves against the local timezone) keeps `uv sync
+# --locked` builds reproducible across hosts and the UTC build container.
+# Bump deliberately when updating dependencies.
+exclude-newer = "2026-05-25T00:00:00Z"
+
 [tool.pyright]
 stubPath = "typings"
 reportAny = false

--- a/admin/uv.lock
+++ b/admin/uv.lock
@@ -3,8 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-05-25T19:37:52.678997989Z"
-exclude-newer-span = "P3D"
+exclude-newer = "2026-05-25T00:00:00Z"
 
 [[package]]
 name = "annotated-types"

--- a/dev/docker-compose.prod.yml
+++ b/dev/docker-compose.prod.yml
@@ -24,7 +24,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: docker.sunet.se/inmor:0.4.0
+    image: docker.sunet.se/inmor:0.4.1
     networks:
       - inmor-net
     healthcheck:
@@ -93,7 +93,7 @@ services:
     build:
       context: ./admin/
       dockerfile: Dockerfile
-    image: docker.sunet.se/inmor-admin:0.4.0
+    image: docker.sunet.se/inmor-admin:0.4.1
     networks:
       - inmor-net
     depends_on:
@@ -129,7 +129,7 @@ services:
       target: production
       args:
         VITE_API_URL: ""
-    image: docker.sunet.se/inmor-frontend:0.4.0
+    image: docker.sunet.se/inmor-frontend:0.4.1
     profiles:
       - frontend
     networks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,14 @@ dependencies = [
 [project.urls]
 Home = "https://github.com/SUNET/inmor"
 
+[tool.uv]
+# Supply-chain cooling window: never resolve distributions published after
+# this date. A fixed UTC timestamp (not a rolling span, and not a bare
+# date which uv resolves against the local timezone) keeps `uv sync
+# --locked` builds reproducible across hosts and the UTC build container.
+# Bump deliberately when updating dependencies.
+exclude-newer = "2026-05-25T00:00:00Z"
+
 [tool.pyright]
 stubPath = "typings"
 reportAny = false

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-05-25T19:39:32.949136416Z"
-exclude-newer-span = "P3D"
+exclude-newer = "2026-05-25T00:00:00Z"
 
 [[package]]
 name = "anyio"


### PR DESCRIPTION
The root and admin uv.lock files were generated with a rolling exclude-newer-span of P3D (a 3-day supply-chain cooling window) that lived only in the lockfiles, not in any committed config. Once more than 3 days had passed, the production Docker build's `uv sync --locked` recomputed the window, decided the lock was stale, and aborted with exit code 1.

Pin a fixed `[tool.uv] exclude-newer` in both pyproject.toml files instead of the rolling span, and regenerate both locks. This keeps the supply-chain cooling protection while making `--locked` builds reproducible.

Use an explicit UTC timestamp ("2026-05-25T00:00:00Z") rather than a bare date: uv resolves a bare YYYY-MM-DD against the local timezone, so a UTC+2 host wrote ...T22:00:00Z into the lock while the UTC build container read ...T00:00:00Z, which still mismatched. The trailing Z makes the host and the container agree.