### PR TITLE
fix: Remove password-based API login

### DIFF
--- a/admin/api_demo/README.md
+++ b/admin/api_demo/README.md
@@ -1,5 +1,9 @@
 This is a demo program to show how the API works.
 
-You will need `cmd2` module to run the REPL.
+You will need the `cmd2` module and an Admin API key to run the REPL.
 
-`uv pip install cmd2` 
+```console
+uv pip install cmd2
+export INMOR_API_KEY="YOUR_KEY_HERE"
+python demo.py
+```

--- a/admin/api_demo/demo.py
+++ b/admin/api_demo/demo.py
@@ -11,6 +11,21 @@ from jwcrypto import jwt
 from jwcrypto.common import json_decode
 
 data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
+api_base_url = "http://localhost:8000"
+
+
+def api_request(method: str, url: str, json_data: dict[Any, Any] | None = None):
+    """Send an authenticated request to the Admin API."""
+    api_key = os.environ.get("INMOR_API_KEY")
+    if not api_key:
+        raise RuntimeError("Set the INMOR_API_KEY environment variable")
+
+    return httpx.request(
+        method,
+        f"{api_base_url}{url}",
+        json=json_data,
+        headers={"X-API-Key": api_key},
+    )
 
 
 def s_y(line: str | int):
@@ -30,28 +45,25 @@ def get_payload(token_str: str):
 
 def get_url(url: str):
     "Get an URL"
-    resp = httpx.get(f"http://localhost:8000{url}")
+    resp = api_request("GET", url)
     return resp.status_code, resp.json()
 
 
 def get_url_json(url: str, j: dict[Any, Any]):
     "Get request with JSON data"
-    headers = {"Content-Type": "application/json"}
-    resp = httpx.request("GET", f"http://localhost:8000{url}", json=j, headers=headers)
+    resp = api_request("GET", url, j)
     return resp.status_code, resp.json()
 
 
 def post_url_json(url: str, j: dict[Any, Any]):
     "POST request with JSON data"
-    headers = {"Content-Type": "application/json"}
-    resp = httpx.request("POST", f"http://localhost:8000{url}", json=j, headers=headers)
+    resp = api_request("POST", url, j)
     return resp.status_code, resp.json()
 
 
 def put_url_json(url: str, j: dict[Any, Any]):
     "PUT request with JSON data"
-    headers = {"Content-Type": "application/json"}
-    resp = httpx.request("PUT", f"http://localhost:8000{url}", json=j, headers=headers)
+    resp = api_request("PUT", url, j)
     return resp.status_code, resp.json()
 
 
@@ -318,5 +330,7 @@ class REPL(Cmd):
 
 
 if __name__ == "__main__":
+    if not os.environ.get("INMOR_API_KEY"):
+        raise SystemExit("Set the INMOR_API_KEY environment variable before starting the demo")
     app = REPL()
     _ = app.cmdloop()

--- a/admin/inmoradmin/api.py
+++ b/admin/inmoradmin/api.py
@@ -37,7 +37,7 @@ api = NinjaAPI(
     description="Admin API for managing Trust Anchor entities, subordinates, and trust marks.",
 )
 
-# Protected router - requires authentication (session or API key)
+# Protected router: API keys for direct callers, allauth sessions for the Admin UI.
 router = Router(auth=combined_auth)
 
 DEFAULTS: dict[str, dict[str, Any]] = settings.TA_DEFAULTS

--- a/admin/inmoradmin/auth.py
+++ b/admin/inmoradmin/auth.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth import logout
 from django.contrib.auth.models import User
 from django.http import HttpRequest, HttpResponse
 from django.middleware.csrf import CsrfViewMiddleware
@@ -151,11 +151,6 @@ class CombinedAuthentication(APIKeyBase):
 combined_auth = [CombinedAuthentication()]
 
 
-class LoginSchema(Schema):
-    username: str
-    password: str
-
-
 class UserSchema(Schema):
     id: int
     username: str
@@ -168,24 +163,9 @@ class MessageSchema(Schema):
     message: str
 
 
-# Auth router for login/logout endpoints (no auth required for these)
+# Browser-session support endpoints. Login is handled exclusively by
+# django-allauth so that its complete authentication flow, including MFA, runs.
 auth_router = Router(tags=["Authentication"])
-
-
-@auth_router.post("/login", response={200: UserSchema, 401: MessageSchema})
-def api_login(request: HttpRequest, data: LoginSchema):
-    """Authenticate user and create session."""
-    user = authenticate(request, username=data.username, password=data.password)
-    if user is not None and isinstance(user, User):
-        login(request, user)
-        return 200, {
-            "id": user.pk,
-            "username": user.username,
-            "email": user.email or "",
-            "is_staff": user.is_staff,
-            "is_superuser": user.is_superuser,
-        }
-    return 401, {"message": "Invalid credentials"}
 
 
 @auth_router.post("/logout", response={200: MessageSchema})

--- a/admin/tests/test_auth.py
+++ b/admin/tests/test_auth.py
@@ -99,6 +99,17 @@ class TestAPIAuthEndpoints:
     """Tests for API authentication endpoints."""
 
     @pytest.mark.django_db
+    def test_password_login_endpoint_not_exposed(self, db):
+        """Passwords cannot be exchanged for a session through the API."""
+        client = Client()
+        response = client.post(
+            "/api/v1/auth/login",
+            data='{"username":"testuser","password":"testpass123"}',
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.django_db
     def test_csrf_endpoint(self, db):
         """Test CSRF token endpoint."""
         client = Client()

--- a/docs/api/admin.rst
+++ b/docs/api/admin.rst
@@ -11,16 +11,14 @@ API Documentation UI: ``http://localhost:8000/api/v1/docs``
 Authentication
 --------------
 
-All ``/api/v1/`` endpoints (except auth endpoints) require authentication.
-The API accepts two authentication methods:
+Direct and programmatic access to protected ``/api/v1/`` endpoints requires an
+API key in the ``X-API-Key`` header (see :doc:`../guides/api-keys`). There is no
+password-login API.
 
-* **Session authentication** -- Login via ``/api/v1/auth/login`` and use the
-  session cookie for subsequent requests
-* **API key authentication** -- Pass an ``X-API-Key`` header (see
-  :doc:`../guides/api-keys`)
-
-Both methods grant the same access. Session auth is used by the Vue frontend;
-API keys are intended for scripts and integrations.
+The browser-based Admin UI uses a Django session established by
+django-allauth at ``/accounts/login/``. This ensures that all configured login
+stages, including MFA, complete before a session is created. Browser session
+cookies are not an authentication mechanism for direct API clients.
 
 Authentication metadata
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,11 +32,14 @@ is attached to ``request.auth_result`` and persisted by the audit log:
   Session-based requests always use the ``"default"`` tenant.
 * ``api_key_name`` -- name of the API key used (``None`` for session auth).
 
-CSRF is enforced for session-based ``POST``/``PUT``/``PATCH``/``DELETE``
-requests. API-key requests bypass CSRF because they do not rely on cookies.
+CSRF is enforced for Admin UI requests authenticated by a browser session.
+API-key requests do not use cookies and therefore do not require CSRF tokens.
 
-Auth Endpoints
-^^^^^^^^^^^^^^
+Browser Session Support Endpoints
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These endpoints support the browser-based Admin UI. They do not provide a way
+for direct API clients to exchange a username and password for a session.
 
 .. list-table::
    :header-rows: 1
@@ -51,28 +52,11 @@ Auth Endpoints
      - ``/api/v1/auth/csrf``
      - Get CSRF token (sets cookie)
    * - POST
-     - ``/api/v1/auth/login``
-     - Login with ``{"username": "...", "password": "..."}``
-   * - POST
      - ``/api/v1/auth/logout``
      - Logout and clear session
    * - GET
      - ``/api/v1/auth/me``
      - Get current authenticated user info
-
-**Login Example:**
-
-.. code-block:: bash
-
-   # Get CSRF token
-   curl -c cookies.txt http://localhost:8000/api/v1/auth/csrf
-
-   # Login
-   curl -b cookies.txt -c cookies.txt \
-     -H "Content-Type: application/json" \
-     -H "X-CSRFToken: <token-from-cookie>" \
-     -X POST http://localhost:8000/api/v1/auth/login \
-     -d '{"username": "admin", "password": "password"}'
 
 **API Key Example:**
 

--- a/docs/api/admin.rst
+++ b/docs/api/admin.rst
@@ -62,7 +62,8 @@ for direct API clients to exchange a username and password for a session.
 
 .. code-block:: bash
 
-   curl -H "X-API-Key: YOUR_KEY_HERE" \
+   export INMOR_API_KEY="YOUR_KEY_HERE"
+   curl -H "X-API-Key: $INMOR_API_KEY" \
         http://localhost:8000/api/v1/trustmarktypes
 
 Trust Mark Types
@@ -142,6 +143,7 @@ Creates a new trust mark type.
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/trustmarktypes \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "tmtype": "https://example.com/trustmarks/member",
@@ -367,6 +369,7 @@ Issues a new trust mark to an entity.
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/trustmarks \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "tmt": 1,
@@ -633,6 +636,7 @@ The API will:
 
    # Then register with the TA
    curl -X POST http://localhost:8000/api/v1/subordinates \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "entityid": "https://example-rp.com",
@@ -772,7 +776,7 @@ authority hints.
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/subordinates/1/renew \
-     -H "Cookie: sessionid=..."
+     -H "X-API-Key: $INMOR_API_KEY"
 
 Fetch Entity Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -848,6 +852,7 @@ validation failure, or no OpenID Federation configuration found.
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/subordinates/fetch-config \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{"url": "https://example-rp.com"}'
 
@@ -887,7 +892,9 @@ The entity statement includes:
 
 .. code-block:: bash
 
-   curl -X POST http://localhost:8000/api/v1/server/entity
+   curl -X POST \
+     -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/server/entity
 
 Create Historical Keys JWT
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -914,7 +921,9 @@ stores it in Redis for the ``/historical_keys`` endpoint.
 
 .. code-block:: bash
 
-   curl -X POST http://localhost:8000/api/v1/server/historical_keys
+   curl -X POST \
+     -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/server/historical_keys
 
 Audit Log
 ---------

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -14,9 +14,8 @@ This guide covers deploying Inmor using Docker Compose for production environmen
    * Add and remove subordinate entities
    * Modify the Trust Anchor's entity configuration
 
-   **In production, you MUST secure the Admin API behind authentication.**
-   At minimum, use HTTP Basic Authentication at the reverse proxy level.
-   Consider additional measures such as:
+   **In production, direct Admin API callers MUST use API keys.** Always use
+   HTTPS and consider additional controls at the reverse proxy, such as:
 
    * IP allowlisting (restrict to management network)
    * VPN-only access
@@ -26,6 +25,11 @@ This guide covers deploying Inmor using Docker Compose for production environmen
    **Never expose the Admin API directly to the internet without authentication.**
 
    See :doc:`reverse-proxy` for configuration examples.
+
+Admin API command examples in this guide assume ``INMOR_API_KEY`` contains a
+key created as described in :doc:`guides/api-keys`::
+
+   export INMOR_API_KEY="YOUR_KEY_HERE"
 
 Architecture
 ------------
@@ -315,10 +319,12 @@ Redis stores the federation runtime data:
 Redis data is ephemeral and can be rebuilt from the database::
 
    # Rebuild entity configuration
-   curl -X POST http://localhost:8000/api/v1/server/entity
+   curl -X POST -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/server/entity
 
    # Rebuild historical keys
-   curl -X POST http://localhost:8000/api/v1/server/historical_keys
+   curl -X POST -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/server/historical_keys
 
    # Reload trust marks from database
    docker compose exec admin python manage.py reload_issued_tms
@@ -784,19 +790,22 @@ After deployment, initialize the Trust Anchor:
 
 1. **Create entity configuration**::
 
-      curl -X POST http://localhost:8000/api/v1/server/entity
+      curl -X POST -H "X-API-Key: $INMOR_API_KEY" \
+        http://localhost:8000/api/v1/server/entity
 
    This creates the TA's self-signed entity statement and stores it in Redis.
 
 2. **Create historical keys JWT** (if you have rotated keys)::
 
-      curl -X POST http://localhost:8000/api/v1/server/historical_keys
+      curl -X POST -H "X-API-Key: $INMOR_API_KEY" \
+        http://localhost:8000/api/v1/server/historical_keys
 
    This creates a signed JWT containing all expired keys from ``historical_keys/``.
 
 3. **Create trust mark types**::
 
       curl -X POST http://localhost:8000/api/v1/trustmarktypes \
+        -H "X-API-Key: $INMOR_API_KEY" \
         -H "Content-Type: application/json" \
         -d '{
           "tmtype": "https://your-domain.example.com/trustmark/member",

--- a/docs/guides/admin-ui.rst
+++ b/docs/guides/admin-ui.rst
@@ -142,8 +142,8 @@ built assets on port 3000.
 Authentication
 --------------
 
-The Admin UI uses session-based authentication with optional Multi-Factor
-Authentication (MFA) support.
+The Admin UI uses a django-allauth browser session with optional Multi-Factor
+Authentication (MFA) support. Direct API clients must use API keys.
 
 .. figure:: /_static/screenshots/mfa-01-login.png
    :alt: Login Page
@@ -154,18 +154,23 @@ Authentication (MFA) support.
 Authentication Flow
 ^^^^^^^^^^^^^^^^^^^
 
-1. **CSRF Token**: On page load, the frontend fetches a CSRF token from
-   ``/api/auth/csrf``
+1. **Authentication Check**: The frontend checks ``/api/v1/auth/me``. An
+   unauthenticated user is redirected to
+   ``/accounts/login/?next=<admin-ui-url>``
 
-2. **Login**: Users authenticate via ``/api/auth/login`` with username/password
+2. **Login**: django-allauth validates the user's primary credentials
 
-3. **MFA Challenge**: If MFA is enabled, user must provide second factor
-   (TOTP code or security key)
+3. **MFA Challenge**: If MFA is enabled, django-allauth requires the configured
+   second factor (TOTP code or security key)
 
-4. **Session**: A session cookie is set for subsequent API requests
+4. **Session**: Only after the complete allauth flow succeeds is a session
+   cookie available to the Admin UI
 
-5. **Auth Check**: The router guard checks ``/api/auth/me`` before each
-   navigation to verify authentication
+5. **Admin API Requests**: The browser sends that session cookie and a CSRF
+   token obtained from ``/api/v1/auth/csrf`` where required
+
+There is no password-login endpoint under ``/api/v1/``. Scripts, integrations,
+and other direct API clients must authenticate with ``X-API-Key``.
 
 For detailed MFA configuration, see :doc:`mfa`.
 

--- a/docs/guides/api-keys.rst
+++ b/docs/guides/api-keys.rst
@@ -1,5 +1,5 @@
 API Key Authentication
-=====================
+======================
 
 Inmor supports API key authentication for programmatic access to the Admin
 API (``/api/v1/``). This allows external tools and scripts to interact with
@@ -12,8 +12,8 @@ the API without session cookies.
 Overview
 --------
 
-API keys provide an alternative to session-based authentication. They are
-useful for:
+API keys are required for direct and programmatic API access. They are useful
+for:
 
 * Automated scripts and CI/CD pipelines
 * External monitoring tools
@@ -104,8 +104,8 @@ Pass the key in the ``X-API-Key`` HTTP header:
    curl -H "X-API-Key: YOUR_KEY_HERE" \
         https://your-server/api/v1/trustmarktypes
 
-All ``/api/v1/`` endpoints accept either a session cookie or an API key.
-Both authentication methods grant the same access.
+Direct requests to protected ``/api/v1/`` endpoints must include an API key.
+Do not copy or reuse an Admin UI browser session in scripts or integrations.
 
 Examples
 ^^^^^^^^
@@ -180,12 +180,13 @@ How It Works
 The authentication flow:
 
 1. Client sends request with ``X-API-Key: <key>`` header
-2. ``APIKeyAuthentication`` (in ``inmoradmin/auth.py``) extracts the header
+2. ``APIKeyAuthBackend`` (in ``inmoradmin/auth.py``) extracts the header
 3. The key is hashed with SHA-256 and looked up in the database
 4. If found, active, and not expired, the request is authenticated as the
    key's associated user
 5. The ``last_used_at`` timestamp is updated
 
-The API router in ``inmoradmin/api.py`` accepts both session and API key
-authentication via ``combined_auth``, so existing session-based workflows
-(including the Vue frontend) continue to work unchanged.
+The API router in ``inmoradmin/api.py`` uses ``combined_auth`` to support API
+keys for direct callers and sessions already established by django-allauth for
+the browser-based Admin UI. The API does not accept usernames and passwords or
+create login sessions itself.

--- a/docs/guides/subordinates.rst
+++ b/docs/guides/subordinates.rst
@@ -5,6 +5,12 @@ Subordinates are entities that register with the Trust Anchor to participate
 in the federation. The Trust Anchor issues signed subordinate statements
 that establish trust chains.
 
+Direct Admin API examples in this guide assume an API key is available::
+
+   export INMOR_API_KEY="YOUR_KEY_HERE"
+
+See :doc:`api-keys` for key creation and management.
+
 Understanding Subordinates
 --------------------------
 
@@ -90,6 +96,7 @@ Fetch the entity's configuration and register it:
 
    # Step 3: Register with the TA
    curl -X POST http://localhost:8000/api/v1/subordinates \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "entityid": "https://example-rp.com",
@@ -161,6 +168,7 @@ enforces for all statements:
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/subordinates \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "entityid": "https://example-op.com",
@@ -191,6 +199,7 @@ Add custom claims to the subordinate statement:
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/subordinates \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "entityid": "https://example-rp.com",
@@ -212,6 +221,7 @@ Set a custom validity period (cannot exceed system default):
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/subordinates \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "entityid": "https://example-rp.com",
@@ -229,7 +239,8 @@ List All Subordinates
 
 .. code-block:: bash
 
-   curl http://localhost:8000/api/v1/subordinates
+   curl -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/subordinates
 
 **Response:**
 
@@ -259,7 +270,8 @@ Get Subordinate by ID
 
 .. code-block:: bash
 
-   curl http://localhost:8000/api/v1/subordinates/1
+   curl -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/subordinates/1
 
 Via Trust Anchor (Public)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -289,6 +301,7 @@ and ``jwks`` fields are required for every update:
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/subordinates/1 \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "metadata": {"openid_relying_party": {"redirect_uris": ["..."]}},
@@ -318,6 +331,7 @@ Disable a subordinate without removing it:
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/subordinates/1 \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "metadata": {"openid_relying_party": {"redirect_uris": ["..."]}},
@@ -509,7 +523,8 @@ Renew a Single Subordinate (API)
 
 .. code-block:: bash
 
-   curl -X POST http://localhost:8000/api/v1/subordinates/1/renew
+   curl -X POST -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/subordinates/1/renew
 
 The endpoint:
 
@@ -560,6 +575,7 @@ Enable auto-renewal to keep subordinate statements fresh:
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/subordinates/1 \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        ...,
@@ -597,6 +613,7 @@ Complete workflow for onboarding a new subordinate:
    .. code-block:: bash
 
       curl -X POST http://localhost:8000/api/v1/subordinates/fetch-config \
+        -H "X-API-Key: $INMOR_API_KEY" \
         -H "Content-Type: application/json" \
         -d '{"url": "https://new-entity.example.com"}'
 
@@ -616,6 +633,7 @@ Complete workflow for onboarding a new subordinate:
    .. code-block:: bash
 
       curl -X POST http://localhost:8000/api/v1/subordinates \
+        -H "X-API-Key: $INMOR_API_KEY" \
         -H "Content-Type: application/json" \
         -d '{
           "entityid": "https://new-entity.example.com",
@@ -629,6 +647,7 @@ Complete workflow for onboarding a new subordinate:
    .. code-block:: bash
 
       curl -X POST http://localhost:8000/api/v1/trustmarks \
+        -H "X-API-Key: $INMOR_API_KEY" \
         -H "Content-Type: application/json" \
         -d '{
           "tmt": 1,
@@ -678,7 +697,8 @@ Check entity type filtering:
 .. code-block:: bash
 
    # Verify entity type in metadata
-   curl http://localhost:8000/api/v1/subordinates/1
+   curl -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/subordinates/1
 
    # Try different entity_type filters
    curl "https://federation.example.com/list?entity_type=openid_relying_party"

--- a/docs/guides/trustmarks.rst
+++ b/docs/guides/trustmarks.rst
@@ -5,6 +5,12 @@ Trust marks are signed assertions about entities in the federation.
 They indicate that an entity meets certain criteria or belongs to a
 specific category defined by the trust mark type.
 
+Direct Admin API examples in this guide assume an API key is available::
+
+   export INMOR_API_KEY="YOUR_KEY_HERE"
+
+See :doc:`api-keys` for key creation and management.
+
 Understanding Trust Marks
 -------------------------
 
@@ -27,6 +33,7 @@ Before issuing trust marks, define the trust mark types your federation supports
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/trustmarktypes \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "tmtype": "https://federation.example.com/trustmarks/member",
@@ -85,6 +92,7 @@ Issue a trust mark to an entity:
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/trustmarks \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "tmt": 1,
@@ -116,6 +124,7 @@ Add custom claims to the trust mark JWT:
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/trustmarks \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "tmt": 1,
@@ -150,6 +159,7 @@ Issue a trust mark with shorter validity than the type default:
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/trustmarks \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "tmt": 1,
@@ -169,7 +179,8 @@ List All Trust Marks
 
 .. code-block:: bash
 
-   curl http://localhost:8000/api/v1/trustmarks
+   curl -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/trustmarks
 
 List Trust Marks for an Entity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -177,6 +188,7 @@ List Trust Marks for an Entity
 .. code-block:: bash
 
    curl -X POST http://localhost:8000/api/v1/trustmarks/list \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{"domain": "https://example-rp.com"}'
 
@@ -187,7 +199,8 @@ Manually renew a trust mark:
 
 .. code-block:: bash
 
-   curl -X POST http://localhost:8000/api/v1/trustmarks/1/renew
+   curl -X POST -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/trustmarks/1/renew
 
 This generates a new JWT with updated ``iat`` and ``exp`` claims while
 preserving all other trust mark properties.
@@ -217,6 +230,7 @@ Revoke a trust mark by setting it to inactive:
 .. code-block:: bash
 
    curl -X PUT http://localhost:8000/api/v1/trustmarks/1 \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{"active": false}'
 
@@ -235,6 +249,7 @@ Update the additional claims in a trust mark:
 .. code-block:: bash
 
    curl -X PUT http://localhost:8000/api/v1/trustmarks/1 \
+     -H "X-API-Key: $INMOR_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
        "additional_claims": {
@@ -444,6 +459,7 @@ Complete workflow for managing trust marks:
    .. code-block:: bash
 
       curl -X POST http://localhost:8000/api/v1/trustmarktypes \
+        -H "X-API-Key: $INMOR_API_KEY" \
         -H "Content-Type: application/json" \
         -d '{
           "tmtype": "https://federation.example.com/trustmarks/verified-rp",
@@ -460,6 +476,7 @@ Complete workflow for managing trust marks:
    .. code-block:: bash
 
       curl -X POST http://localhost:8000/api/v1/trustmarks \
+        -H "X-API-Key: $INMOR_API_KEY" \
         -H "Content-Type: application/json" \
         -d '{
           "tmt": 1,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,9 +16,9 @@ The system consists of two components:
 
 .. danger::
 
-   **Production Security:** The Admin API must be protected with authentication
-   (at minimum HTTP Basic Auth) before exposing to any network. See
-   :ref:`securing-admin-api` for details.
+   **Production Security:** Direct Admin API clients must authenticate with an
+   API key. Always use HTTPS and restrict network access before exposing the
+   Admin API. See :ref:`securing-admin-api` for details.
 
 Quick Start
 -----------
@@ -34,9 +34,14 @@ The fastest way to get Inmor running is with Docker Compose::
    just build-rs
    just up
 
+   # Set a key created as described in the API key guide
+   export INMOR_API_KEY="YOUR_KEY_HERE"
+
    # Initialize the Trust Anchor
-   curl -X POST http://localhost:8000/api/v1/server/entity
-   curl -X POST http://localhost:8000/api/v1/server/historical_keys
+   curl -X POST -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/server/entity
+   curl -X POST -H "X-API-Key: $INMOR_API_KEY" \
+     http://localhost:8000/api/v1/server/historical_keys
 
 The repository includes development signing keys, so no key generation is needed
 for getting started. For production, you should generate your own keys.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,13 +51,18 @@ Quick Installation
 
       just up
 
-5. Initialize the Trust Anchor::
+5. Set ``INMOR_API_KEY`` to a key created as described in
+   :doc:`guides/api-keys`, then initialize the Trust Anchor::
+
+      export INMOR_API_KEY="YOUR_KEY_HERE"
 
       # Create the entity configuration
-      curl -X POST http://localhost:8000/api/v1/server/entity
+      curl -X POST -H "X-API-Key: $INMOR_API_KEY" \
+        http://localhost:8000/api/v1/server/entity
 
       # Create historical keys JWT (if you have any)
-      curl -X POST http://localhost:8000/api/v1/server/historical_keys
+      curl -X POST -H "X-API-Key: $INMOR_API_KEY" \
+        http://localhost:8000/api/v1/server/historical_keys
 
 The Trust Anchor is now running at ``http://localhost:8080`` and the Admin API at ``http://localhost:8000``.
 
@@ -152,7 +157,8 @@ Verifying Installation
 
 3. Test the Admin API::
 
-      curl http://localhost:8000/api/v1/trustmarktypes
+      curl -H "X-API-Key: $INMOR_API_KEY" \
+        http://localhost:8000/api/v1/trustmarktypes
 
    This should return an empty list or existing trust mark types.
 

--- a/docs/reverse-proxy.rst
+++ b/docs/reverse-proxy.rst
@@ -49,10 +49,12 @@ Securing the Admin API
    * Add rogue subordinates to the federation
    * Modify or destroy the Trust Anchor configuration
 
-   **At minimum, protect the Admin API with HTTP Basic Authentication.**
+   Direct API callers must send an Inmor API key in ``X-API-Key``. Reverse
+   proxy controls such as HTTP Basic Authentication, IP allowlisting, VPN, or
+   mTLS can provide an additional layer, but do not replace the API key.
 
-Basic Authentication Setup
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Optional Additional Basic Authentication
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **nginx**
 
@@ -142,7 +144,7 @@ Create ``/etc/nginx/sites-available/inmor.conf``:
        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;
        ssl_prefer_server_ciphers off;
 
-       # REQUIRED: Basic authentication
+       # Optional: additional Basic authentication at the proxy
        auth_basic "Admin API";
        auth_basic_user_file /etc/nginx/.htpasswd;
 
@@ -200,7 +202,7 @@ If you prefer a single domain with path-based routing:
            proxy_set_header X-Forwarded-Proto $scheme;
        }
 
-       # Admin API (protected with basic auth)
+       # Admin API (Inmor API-key auth, plus optional proxy Basic Auth)
        location /api/ {
            auth_basic "Admin API";
            auth_basic_user_file /etc/nginx/.htpasswd;
@@ -293,7 +295,7 @@ Create ``/etc/apache2/sites-available/inmor.conf`` (Debian/Ubuntu) or
 
        RequestHeader set X-Forwarded-Proto "https"
 
-       # REQUIRED: Basic authentication
+       # Optional: additional Basic authentication at the proxy
        <Location />
            AuthType Basic
            AuthName "Admin API"
@@ -344,7 +346,7 @@ Single Domain Setup (Apache)
        ProxyPassMatch ^/(fetch|list|resolve|trust_mark|trust_mark_list|trust_mark_status|historical_keys|collection)$ http://127.0.0.1:8080/$1
        ProxyPassReverse / http://127.0.0.1:8080/
 
-       # Admin API (protected with basic auth)
+       # Admin API (Inmor API-key auth, plus optional proxy Basic Auth)
        <Location /api/>
            AuthType Basic
            AuthName "Admin API"
@@ -397,7 +399,7 @@ Create ``/etc/caddy/Caddyfile``:
 
    # Admin Portal - Management API (protected)
    admin.federation.example.com {
-       # REQUIRED: Basic authentication
+       # Optional: additional Basic authentication at the proxy
        basicauth {
            admin $2a$14$Zkx19XLiW6VYouLHR5NmfOFU0z2GTNmpkT/5qqR7hx4IjWJPDhjvG
        }
@@ -455,7 +457,7 @@ Single Domain Setup (Caddy)
            reverse_proxy localhost:8080
        }
 
-       # Admin API (protected with basic auth)
+       # Admin API (Inmor API-key auth, plus optional proxy Basic Auth)
        handle /api/* {
            basicauth {
                admin $2a$14$...
@@ -537,8 +539,8 @@ Security Best Practices
 
 1. **Always Protect Admin API**
 
-   Never expose the Admin API without authentication. Use Basic Auth at minimum,
-   consider IP allowlisting or VPN for additional security.
+   Require Inmor API keys for direct API calls. Always use HTTPS, and consider
+   proxy Basic Auth, IP allowlisting, VPN, or mTLS as additional controls.
 
 2. **Use Strong TLS Configuration**
 
@@ -607,6 +609,9 @@ Testing the Setup
 
       curl "https://federation.example.com/resolve?sub=https://example-rp.com&trust_anchor=https://federation.example.com"
 
-3. Test Admin API with authentication::
+3. Test the Admin API with an Inmor API key. If you enabled the optional proxy
+   Basic Authentication shown above, supply both credentials::
 
-      curl -u admin:password https://admin.federation.example.com/api/v1/trustmarktypes
+      curl -u admin:password \
+        -H "X-API-Key: $INMOR_API_KEY" \
+        https://admin.federation.example.com/api/v1/trustmarktypes

--- a/scripts/record_demo.py
+++ b/scripts/record_demo.py
@@ -63,14 +63,18 @@ def wait_and_click(page: Page, selector: str, wait_time: float = 0.5):
 
 
 def login(page: Page):
-    """Login to the admin UI."""
+    """Login through the django-allauth browser flow."""
     print("Logging in...")
     page.goto("http://localhost:5173/login")
     time.sleep(2)
 
-    # Fill login form
-    username_input = page.locator('input[placeholder="Enter your username"]')
-    password_input = page.locator('input[placeholder="Enter your password"]')
+    # The frontend does not collect credentials. Follow its Sign In link to
+    # django-allauth, which runs every configured authentication stage.
+    page.get_by_role("button", name="Sign In").click()
+    page.wait_for_url("http://localhost:5173/accounts/login/**", timeout=10000)
+
+    username_input = page.locator("#id_login")
+    password_input = page.locator("#id_password")
 
     username_input.click()
     username_input.type("kushal", delay=80)
@@ -80,8 +84,9 @@ def login(page: Page):
     password_input.type("redHat1234", delay=80)
     time.sleep(0.5)
 
-    # Click login button
-    page.click('button[type="submit"]')
+    # Submit the allauth form. Users with MFA enabled continue through the
+    # configured MFA challenge before allauth redirects to the Admin UI.
+    page.get_by_role("button", name="Sign In").click()
     time.sleep(2)
 
     # Wait for redirect to home


### PR DESCRIPTION
Require API keys for direct API access and use django-allauth sessions for browser authentication. Remove stale frontend and documentation references, update security PoCs, and add regression coverage.