### PR TITLE
fix: harden federation fetches against SSRF

### DIFF
--- a/admin/entities/lib.py
+++ b/admin/entities/lib.py
@@ -22,14 +22,6 @@ INSIDE_CONTAINER = os.environ.get("INSIDE_CONTAINER")
 
 logger = logging.getLogger(__name__)
 
-# Pinned URLs use the resolved IP as HTTPX's pool key. Do not retain those
-# connections across requests for different TLS hostnames that share an IP.
-_HTTP_CLIENT = httpx.Client(
-    follow_redirects=False,
-    trust_env=False,
-    timeout=10.0,
-    limits=httpx.Limits(max_keepalive_connections=0),
-)
 _WELL_KNOWN_PATH = "/.well-known/openid-federation"
 _PUBLIC_IPV6_NETWORK = ip_network("2000::/3")
 _PUBLIC_NAT64_NETWORK = ip_network("64:ff9b::/96")
@@ -37,6 +29,16 @@ _PUBLIC_NAT64_NETWORK = ip_network("64:ff9b::/96")
 
 class SubordinateRequest(BaseModel):
     entity: str
+
+
+def _new_federation_client(timeout: float) -> httpx.Client:
+    """Create a fetch-scoped client so cookies and pools cannot cross origins."""
+    return httpx.Client(
+        follow_redirects=False,
+        trust_env=False,
+        timeout=timeout,
+        limits=httpx.Limits(max_keepalive_connections=0),
+    )
 
 
 def _is_public_federation_address(address: IPv4Address | IPv6Address) -> bool:
@@ -110,22 +112,23 @@ def _federation_get(url: str, timeout: float = 10.0) -> httpx.Response:
         host_header = f"{host_header}:{port}"
 
     last_error: httpx.TransportError | None = None
-    for address in addresses:
-        pinned_host = f"[{address}]" if ":" in address else address
-        pinned_url = urlunsplit(
-            (parsed.scheme, f"{pinned_host}:{port}", parsed.path or "/", parsed.query, "")
-        )
-        request = _HTTP_CLIENT.build_request(
-            "GET",
-            pinned_url,
-            headers={"Host": host_header},
-            timeout=timeout,
-            extensions={"sni_hostname": ascii_hostname},
-        )
-        try:
-            return _HTTP_CLIENT.send(request)
-        except httpx.TransportError as error:
-            last_error = error
+    with _new_federation_client(timeout) as client:
+        for address in addresses:
+            pinned_host = f"[{address}]" if ":" in address else address
+            pinned_url = urlunsplit(
+                (parsed.scheme, f"{pinned_host}:{port}", parsed.path or "/", parsed.query, "")
+            )
+            request = client.build_request(
+                "GET",
+                pinned_url,
+                headers={"Host": host_header},
+                timeout=timeout,
+                extensions={"sni_hostname": ascii_hostname},
+            )
+            try:
+                return client.send(request)
+            except httpx.TransportError as error:
+                last_error = error
 
     assert last_error is not None
     raise last_error

--- a/admin/entities/lib.py
+++ b/admin/entities/lib.py
@@ -103,7 +103,7 @@ def _federation_get(url: str, timeout: float = 10.0) -> httpx.Response:
             pinned_url,
             headers={"Host": host_header},
             timeout=timeout,
-            extensions={"sni_hostname": ascii_hostname},
+            extensions={"sni_hostname": ascii_hostname.encode("ascii")},
         )
         try:
             return _HTTP_CLIENT.send(request)

--- a/admin/entities/lib.py
+++ b/admin/entities/lib.py
@@ -3,7 +3,7 @@ import logging
 import os
 import socket
 from datetime import datetime, timedelta
-from ipaddress import ip_address
+from ipaddress import IPv4Address, IPv6Address, ip_address, ip_network
 from typing import Any, cast
 from urllib.parse import SplitResult, urlparse, urlsplit, urlunsplit
 
@@ -31,10 +31,27 @@ _HTTP_CLIENT = httpx.Client(
     limits=httpx.Limits(max_keepalive_connections=0),
 )
 _WELL_KNOWN_PATH = "/.well-known/openid-federation"
+_PUBLIC_IPV6_NETWORK = ip_network("2000::/3")
+_PUBLIC_NAT64_NETWORK = ip_network("64:ff9b::/96")
 
 
 class SubordinateRequest(BaseModel):
     entity: str
+
+
+def _is_public_federation_address(address: IPv4Address | IPv6Address) -> bool:
+    """Return whether an address is safe for a production federation fetch."""
+    if isinstance(address, IPv4Address):
+        return address.is_global and not address.is_multicast and not address.is_reserved
+    if address in _PUBLIC_NAT64_NETWORK:
+        embedded = IPv4Address(address.packed[-4:])
+        return embedded.is_global and not embedded.is_multicast and not embedded.is_reserved
+    return (
+        address in _PUBLIC_IPV6_NETWORK
+        and address.is_global
+        and not address.is_multicast
+        and not address.is_reserved
+    )
 
 
 def _resolve_federation_destination(url: str) -> tuple[SplitResult, list[str]]:
@@ -69,7 +86,7 @@ def _resolve_federation_destination(url: str) -> tuple[SplitResult, list[str]]:
             resolved_ip = ip_address(normalized)
         except ValueError as error:
             raise ValueError(f"DNS returned an invalid address for {parsed.hostname}") from error
-        if not allow_http and (not resolved_ip.is_global or resolved_ip.is_multicast):
+        if not allow_http and not _is_public_federation_address(resolved_ip):
             raise ValueError(f"Federation URL resolves to private/internal address {resolved_ip}")
         canonical = str(resolved_ip)
         if canonical not in addresses:
@@ -103,7 +120,7 @@ def _federation_get(url: str, timeout: float = 10.0) -> httpx.Response:
             pinned_url,
             headers={"Host": host_header},
             timeout=timeout,
-            extensions={"sni_hostname": ascii_hostname.encode("ascii")},
+            extensions={"sni_hostname": ascii_hostname},
         )
         try:
             return _HTTP_CLIENT.send(request)

--- a/admin/entities/lib.py
+++ b/admin/entities/lib.py
@@ -1,9 +1,11 @@
 import json
 import logging
 import os
+import socket
 from datetime import datetime, timedelta
+from ipaddress import ip_address
 from typing import Any, cast
-from urllib.parse import urlparse
+from urllib.parse import SplitResult, urlparse, urlsplit, urlunsplit
 
 import httpx
 from django.conf import settings
@@ -20,9 +22,105 @@ INSIDE_CONTAINER = os.environ.get("INSIDE_CONTAINER")
 
 logger = logging.getLogger(__name__)
 
+# Pinned URLs use the resolved IP as HTTPX's pool key. Do not retain those
+# connections across requests for different TLS hostnames that share an IP.
+_HTTP_CLIENT = httpx.Client(
+    follow_redirects=False,
+    trust_env=False,
+    timeout=10.0,
+    limits=httpx.Limits(max_keepalive_connections=0),
+)
+_WELL_KNOWN_PATH = "/.well-known/openid-federation"
+
 
 class SubordinateRequest(BaseModel):
     entity: str
+
+
+def _resolve_federation_destination(url: str) -> tuple[SplitResult, list[str]]:
+    """Validate a federation URL and return the exact addresses to connect to."""
+    try:
+        parsed = urlsplit(url)
+        port = parsed.port
+    except ValueError as error:
+        raise ValueError(f"Invalid federation URL: {error}") from error
+
+    allow_http = settings.FEDERATION_FETCH_ALLOW_HTTP
+    if parsed.scheme != "https" and not (allow_http and parsed.scheme == "http"):
+        raise ValueError("Federation fetches require HTTPS")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("Federation URLs must not contain credentials")
+    if parsed.fragment:
+        raise ValueError("Federation URLs must not contain fragments")
+    if not parsed.hostname:
+        raise ValueError("Federation URL has no host")
+
+    port = port or (443 if parsed.scheme == "https" else 80)
+    try:
+        answers = socket.getaddrinfo(parsed.hostname, port, type=socket.SOCK_STREAM)
+    except OSError as error:
+        raise ValueError(f"DNS resolution failed for {parsed.hostname}: {error}") from error
+
+    addresses: list[str] = []
+    for answer in answers:
+        address = answer[4][0]
+        normalized = address.split("%", 1)[0]
+        try:
+            resolved_ip = ip_address(normalized)
+        except ValueError as error:
+            raise ValueError(f"DNS returned an invalid address for {parsed.hostname}") from error
+        if not allow_http and (not resolved_ip.is_global or resolved_ip.is_multicast):
+            raise ValueError(f"Federation URL resolves to private/internal address {resolved_ip}")
+        canonical = str(resolved_ip)
+        if canonical not in addresses:
+            addresses.append(canonical)
+
+    if not addresses:
+        raise ValueError(f"DNS resolution returned no addresses for {parsed.hostname}")
+    return parsed, addresses
+
+
+def _federation_get(url: str, timeout: float = 10.0) -> httpx.Response:
+    """GET a federation URL without redirects or a DNS validation/use race."""
+    parsed, addresses = _resolve_federation_destination(url)
+    hostname = parsed.hostname
+    assert hostname is not None
+    ascii_hostname = hostname.encode("idna").decode("ascii")
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    default_port = 443 if parsed.scheme == "https" else 80
+    host_header = f"[{ascii_hostname}]" if ":" in ascii_hostname else ascii_hostname
+    if parsed.port is not None and port != default_port:
+        host_header = f"{host_header}:{port}"
+
+    last_error: httpx.TransportError | None = None
+    for address in addresses:
+        pinned_host = f"[{address}]" if ":" in address else address
+        pinned_url = urlunsplit(
+            (parsed.scheme, f"{pinned_host}:{port}", parsed.path or "/", parsed.query, "")
+        )
+        request = _HTTP_CLIENT.build_request(
+            "GET",
+            pinned_url,
+            headers={"Host": host_header},
+            timeout=timeout,
+            extensions={"sni_hostname": ascii_hostname},
+        )
+        try:
+            return _HTTP_CLIENT.send(request)
+        except httpx.TransportError as error:
+            last_error = error
+
+    assert last_error is not None
+    raise last_error
+
+
+def _entity_configuration_url(entity_id: str) -> str:
+    """Append the well-known path without allowing query/fragment truncation."""
+    parsed = urlsplit(entity_id)
+    if parsed.query or parsed.fragment:
+        raise ValueError("Entity IDs must not contain a query or fragment")
+    path = f"{parsed.path.rstrip('/')}{_WELL_KNOWN_PATH}"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
 
 
 def fetch_entity_configuration(
@@ -41,7 +139,7 @@ def fetch_entity_configuration(
         keyset = jwk.JWKSet.from_json(keys_str)
     else:
         raise ValueError("Missing JWKS")
-    resp = httpx.get(f"{entityid}/.well-known/openid-federation")
+    resp = _federation_get(_entity_configuration_url(entityid))
     text = resp.text
     jwt_net: JWT = jwt.JWT(jwt=text, key=keyset)
     return jwt_net, keyset, text
@@ -283,7 +381,7 @@ def update_redis_with_subordinate(
 
 def fetch_jwks_from_uri(uri: str) -> JWKSet:
     """Fetch a JWKS from a remote jwks_uri endpoint."""
-    resp = httpx.get(uri, timeout=10)
+    resp = _federation_get(uri)
     resp.raise_for_status()
     return JWKSet.from_json(resp.text)
 
@@ -316,7 +414,7 @@ def self_validate(token: jwt.JWT) -> dict[str, Any]:
 
 def fetch_payload(entity_id: str):
     """Fetches entity and validates and returns payload and JWT token as string"""
-    resp = httpx.get(f"{entity_id}/.well-known/openid-federation")
+    resp = _federation_get(_entity_configuration_url(entity_id))
     if resp.status_code != 200:
         raise Exception(f"Fetching payload returns {resp.status_code} for {entity_id}")
     text = resp.text
@@ -367,7 +465,7 @@ def fetch_subordinate_statements(authority_hints: list[str], entity_id: str, r: 
             # We have a fetch endpoint
             url = f"{fetch_endpoint}/?sub={entity_id}"
             logger.info(f"Fetching subordinate statement: {url}")
-            resp = httpx.get(url)
+            resp = _federation_get(url)
             if resp.status_code != 200:
                 logger.warning(
                     f"Fetching subordinate statement returns {resp.status_code} for {entity_id}"
@@ -419,7 +517,7 @@ def tree_walking(entity_id: str, r: Redis, visited: set[str] | None = None):
         if not list_endpoint:
             logger.warning(f"{entity_id} does not have a list endpoint")
             return visited
-        resp = httpx.get(list_endpoint)
+        resp = _federation_get(list_endpoint)
         subordinates = json.loads(resp.text)
         for subordinate in subordinates:
             if subordinate in visited:

--- a/admin/inmoradmin/settings.py
+++ b/admin/inmoradmin/settings.py
@@ -34,6 +34,14 @@ DEBUG = os.environ.get("DEBUG", "True").lower() in ("true", "1", "yes")
 
 ALLOWED_HOSTS: list[str] = os.environ.get("ALLOWED_HOSTS", "localhost,127.0.0.1,admin").split(",")
 
+# Production federation fetches require public HTTPS destinations. Development
+# Compose explicitly opts into HTTP/private services used by its local examples.
+FEDERATION_FETCH_ALLOW_HTTP = os.environ.get("FEDERATION_FETCH_ALLOW_HTTP", "false").lower() in (
+    "true",
+    "1",
+    "yes",
+)
+
 
 # Application definition
 

--- a/admin/tests/test_api.py
+++ b/admin/tests/test_api.py
@@ -28,6 +28,7 @@ data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 def test_fetch_config_blocks_private_destination(
     auth_client: Client, monkeypatch, settings, url, expected_message
 ):
+    """Reject private fetch targets before the API reaches the transport."""
     settings.FEDERATION_FETCH_ALLOW_HTTP = False
     monkeypatch.setattr(
         socket,

--- a/admin/tests/test_api.py
+++ b/admin/tests/test_api.py
@@ -44,8 +44,8 @@ def test_fetch_config_blocks_private_destination(
         ],
     )
     monkeypatch.setattr(
-        "entities.lib._HTTP_CLIENT.send",
-        lambda request: pytest.fail("blocked destination reached the transport"),
+        "entities.lib.httpx.Client.send",
+        lambda _client, request: pytest.fail("blocked destination reached the transport"),
     )
 
     response = auth_client.post(

--- a/admin/tests/test_api.py
+++ b/admin/tests/test_api.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+import socket
 from typing import Any
 
 import pytest
@@ -14,6 +15,46 @@ from entities.lib import self_validate
 
 
 data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("url", "expected_message"),
+    [
+        ("https://internal.example#ignored", "query or fragment"),
+        ("https://internal.example", "private/internal"),
+    ],
+)
+def test_fetch_config_blocks_private_destination(
+    auth_client: Client, monkeypatch, settings, url, expected_message
+):
+    settings.FEDERATION_FETCH_ALLOW_HTTP = False
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (
+                socket.AF_INET,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                ("127.0.0.1", 443),
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "entities.lib._HTTP_CLIENT.send",
+        lambda request: pytest.fail("blocked destination reached the transport"),
+    )
+
+    response = auth_client.post(
+        "/api/v1/subordinates/fetch-config",
+        data=json.dumps({"url": url}),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert expected_message in response.json()["message"]
 
 
 def get_payload(token_str: str):

--- a/admin/tests/test_entitylib.py
+++ b/admin/tests/test_entitylib.py
@@ -1,7 +1,9 @@
 import json
 import os
+import socket
 from typing import Any
 
+import httpx
 import pytest
 from django.test import TestCase
 from jwcrypto import jwt
@@ -27,6 +29,117 @@ def test_fetch_entity_configuration_with_keys():
     keys = metadata["openid_relying_party"]["jwks"]
     metadata.pop("openid_relying_party")
     _ = lib.fetch_entity_configuration("https://fakerp0.labb.sunet.se", keys)
+
+
+def test_federation_get_pins_validated_public_address(monkeypatch, settings):
+    settings.FEDERATION_FETCH_ALLOW_HTTP = False
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("8.8.8.8", 443))
+        ],
+    )
+    captured = []
+
+    def send(request):
+        captured.append(request)
+        return httpx.Response(302, headers={"Location": "http://127.0.0.1/"}, request=request)
+
+    monkeypatch.setattr(lib._HTTP_CLIENT, "send", send)
+
+    response = lib._federation_get("https://federation.example/path?value=1")
+
+    assert response.status_code == 302
+    assert len(captured) == 1  # redirects stay disabled
+    assert str(captured[0].url) == "https://8.8.8.8/path?value=1"
+    assert captured[0].headers["Host"] == "federation.example"
+    assert captured[0].extensions["sni_hostname"] == "federation.example"
+
+
+@pytest.mark.parametrize(
+    "address",
+    ["127.0.0.1", "169.254.169.254", "10.0.0.1", "::ffff:127.0.0.1", "ff02::1"],
+)
+def test_federation_get_rejects_internal_addresses(monkeypatch, settings, address):
+    settings.FEDERATION_FETCH_ALLOW_HTTP = False
+    family = socket.AF_INET6 if ":" in address else socket.AF_INET
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (address, 443))
+        ],
+    )
+
+    with pytest.raises(ValueError, match="private/internal"):
+        lib._federation_get("https://federation.example/path")
+
+
+def test_federation_get_rejects_any_internal_dns_answer(monkeypatch, settings):
+    settings.FEDERATION_FETCH_ALLOW_HTTP = False
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("8.8.8.8", 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("127.0.0.1", 443)),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="private/internal"):
+        lib._federation_get("https://federation.example/path")
+
+
+def test_federation_get_preserves_explicit_development_mode(monkeypatch, settings):
+    settings.FEDERATION_FETCH_ALLOW_HTTP = True
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("127.0.0.1", 8080))
+        ],
+    )
+    captured = []
+
+    def send(request):
+        captured.append(request)
+        return httpx.Response(200, text="ok", request=request)
+
+    monkeypatch.setattr(lib._HTTP_CLIENT, "send", send)
+
+    response = lib._federation_get("http://ta:8080/fetch")
+
+    assert response.text == "ok"
+    assert str(captured[0].url) == "http://127.0.0.1:8080/fetch"
+    assert captured[0].headers["Host"] == "ta:8080"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://example.com/path",
+        "https://user@example.com/path",
+        "https://example.com/path#fragment",
+    ],
+)
+def test_federation_get_rejects_unsafe_urls(monkeypatch, settings, url):
+    settings.FEDERATION_FETCH_ALLOW_HTTP = False
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *args, **kwargs: pytest.fail("DNS used"))
+
+    with pytest.raises(ValueError):
+        lib._federation_get(url)
+
+
+def test_entity_configuration_url_rejects_query_and_fragment():
+    for entity_id in ["https://example.com?target=other", "https://example.com/#ignored"]:
+        with pytest.raises(ValueError, match="query or fragment"):
+            lib._entity_configuration_url(entity_id)
+
+    assert (
+        lib._entity_configuration_url("https://example.com/tenant/")
+        == "https://example.com/tenant/.well-known/openid-federation"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/admin/tests/test_entitylib.py
+++ b/admin/tests/test_entitylib.py
@@ -32,6 +32,7 @@ def test_fetch_entity_configuration_with_keys():
 
 
 def test_federation_get_pins_validated_public_address(monkeypatch, settings):
+    """Connect to the validated address while retaining the HTTP and TLS host."""
     settings.FEDERATION_FETCH_ALLOW_HTTP = False
     monkeypatch.setattr(
         socket,
@@ -43,6 +44,7 @@ def test_federation_get_pins_validated_public_address(monkeypatch, settings):
     captured = []
 
     def send(request):
+        """Capture the pinned request and return a redirect without following it."""
         captured.append(request)
         return httpx.Response(302, headers={"Location": "http://127.0.0.1/"}, request=request)
 
@@ -54,7 +56,7 @@ def test_federation_get_pins_validated_public_address(monkeypatch, settings):
     assert len(captured) == 1  # redirects stay disabled
     assert str(captured[0].url) == "https://8.8.8.8/path?value=1"
     assert captured[0].headers["Host"] == "federation.example"
-    assert captured[0].extensions["sni_hostname"] == b"federation.example"
+    assert captured[0].extensions["sni_hostname"] == "federation.example"
 
 
 @pytest.mark.parametrize(
@@ -62,6 +64,7 @@ def test_federation_get_pins_validated_public_address(monkeypatch, settings):
     ["127.0.0.1", "169.254.169.254", "10.0.0.1", "::ffff:127.0.0.1", "ff02::1"],
 )
 def test_federation_get_rejects_internal_addresses(monkeypatch, settings, address):
+    """Reject non-public IPv4, IPv6, and mapped DNS answers."""
     settings.FEDERATION_FETCH_ALLOW_HTTP = False
     family = socket.AF_INET6 if ":" in address else socket.AF_INET
     monkeypatch.setattr(
@@ -77,6 +80,7 @@ def test_federation_get_rejects_internal_addresses(monkeypatch, settings, addres
 
 
 def test_federation_get_rejects_any_internal_dns_answer(monkeypatch, settings):
+    """Reject a DNS response if any returned address is internal."""
     settings.FEDERATION_FETCH_ALLOW_HTTP = False
     monkeypatch.setattr(
         socket,
@@ -91,7 +95,63 @@ def test_federation_get_rejects_any_internal_dns_answer(monkeypatch, settings):
         lib._federation_get("https://federation.example/path")
 
 
+@pytest.mark.parametrize("address", ["4000::1", "fec0::1"])
+def test_federation_get_rejects_reserved_ipv6(monkeypatch, settings, address):
+    """Reject reserved and deprecated IPv6 space that Python marks global."""
+    settings.FEDERATION_FETCH_ALLOW_HTTP = False
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET6, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (address, 443))
+        ],
+    )
+
+    with pytest.raises(ValueError, match="private/internal"):
+        lib._resolve_federation_destination("https://federation.example/path")
+
+
+@pytest.mark.parametrize("address", ["64:ff9b::7f00:1", "64:ff9b:1::1"])
+def test_federation_get_rejects_unsafe_nat64(monkeypatch, settings, address):
+    """Reject NAT64 addresses targeting private IPv4 or local-use space."""
+    settings.FEDERATION_FETCH_ALLOW_HTTP = False
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET6, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (address, 443))
+        ],
+    )
+
+    with pytest.raises(ValueError, match="private/internal"):
+        lib._resolve_federation_destination("https://federation.example/path")
+
+
+@pytest.mark.parametrize("address", ["2607:f8b0:4004:800::200e", "64:ff9b::5db8:d822"])
+def test_federation_get_allows_public_ipv6(monkeypatch, settings, address):
+    """Retain ordinary public IPv6 and public-destination NAT64 addresses."""
+    settings.FEDERATION_FETCH_ALLOW_HTTP = False
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                socket.IPPROTO_TCP,
+                "",
+                (address, 443),
+            )
+        ],
+    )
+
+    _, addresses = lib._resolve_federation_destination("https://federation.example/path")
+
+    assert addresses == [address]
+
+
 def test_federation_get_preserves_explicit_development_mode(monkeypatch, settings):
+    """Allow explicit local HTTP destinations only in development mode."""
     settings.FEDERATION_FETCH_ALLOW_HTTP = True
     monkeypatch.setattr(
         socket,
@@ -103,6 +163,7 @@ def test_federation_get_preserves_explicit_development_mode(monkeypatch, setting
     captured = []
 
     def send(request):
+        """Capture the development request and return a successful response."""
         captured.append(request)
         return httpx.Response(200, text="ok", request=request)
 
@@ -124,6 +185,7 @@ def test_federation_get_preserves_explicit_development_mode(monkeypatch, setting
     ],
 )
 def test_federation_get_rejects_unsafe_urls(monkeypatch, settings, url):
+    """Reject unsafe schemes, credentials, and fragments before DNS lookup."""
     settings.FEDERATION_FETCH_ALLOW_HTTP = False
     monkeypatch.setattr(socket, "getaddrinfo", lambda *args, **kwargs: pytest.fail("DNS used"))
 
@@ -132,6 +194,7 @@ def test_federation_get_rejects_unsafe_urls(monkeypatch, settings, url):
 
 
 def test_entity_configuration_url_rejects_query_and_fragment():
+    """Append the well-known path without query or fragment truncation."""
     for entity_id in ["https://example.com?target=other", "https://example.com/#ignored"]:
         with pytest.raises(ValueError, match="query or fragment"):
             lib._entity_configuration_url(entity_id)

--- a/admin/tests/test_entitylib.py
+++ b/admin/tests/test_entitylib.py
@@ -43,12 +43,12 @@ def test_federation_get_pins_validated_public_address(monkeypatch, settings):
     )
     captured = []
 
-    def send(request):
+    def send(_client, request):
         """Capture the pinned request and return a redirect without following it."""
         captured.append(request)
         return httpx.Response(302, headers={"Location": "http://127.0.0.1/"}, request=request)
 
-    monkeypatch.setattr(lib._HTTP_CLIENT, "send", send)
+    monkeypatch.setattr(httpx.Client, "send", send)
 
     response = lib._federation_get("https://federation.example/path?value=1")
 
@@ -150,6 +150,88 @@ def test_federation_get_allows_public_ipv6(monkeypatch, settings, address):
     assert addresses == [address]
 
 
+def test_federation_get_does_not_replay_cookies_between_origins(monkeypatch, settings):
+    """Keep cookies isolated when separate origins resolve to the same IP."""
+    settings.FEDERATION_FETCH_ALLOW_HTTP = False
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("8.8.8.8", 443))
+        ],
+    )
+    captured = []
+    clients = []
+    real_client = httpx.Client
+
+    def handler(request):
+        """Set a cookie on the first origin and capture both pinned requests."""
+        captured.append(request)
+        headers = {"Set-Cookie": "session=secret; Path=/"} if len(captured) == 1 else {}
+        return httpx.Response(200, headers=headers)
+
+    def client_with_test_transport(*args, **kwargs):
+        """Inject the test transport while retaining the production factory."""
+        kwargs["transport"] = httpx.MockTransport(handler)
+        client = real_client(*args, **kwargs)
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(lib.httpx, "Client", client_with_test_transport)
+
+    lib._federation_get("https://first.example/path")
+    lib._federation_get("https://second.example/path")
+
+    assert captured[0].headers["Host"] == "first.example"
+    assert captured[1].headers["Host"] == "second.example"
+    assert "Cookie" not in captured[1].headers
+    assert len(clients) == 2
+    assert clients[0] is not clients[1]
+    assert all(client.is_closed for client in clients)
+
+
+def test_federation_get_retries_validated_addresses(monkeypatch, settings):
+    """Retry validated addresses without changing the original Host or SNI."""
+    settings.FEDERATION_FETCH_ALLOW_HTTP = False
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("8.8.8.8", 443)),
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("1.1.1.1", 443)),
+        ],
+    )
+    captured = []
+
+    def handler(request):
+        """Fail the first address and return a response from the second."""
+        captured.append(request)
+        if len(captured) == 1:
+            raise httpx.ConnectError("first address failed", request=request)
+        return httpx.Response(200, text="ok")
+
+    def new_client(timeout):
+        """Create a fetch-scoped client using the deterministic test transport."""
+        return httpx.Client(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+            timeout=timeout,
+        )
+
+    monkeypatch.setattr(lib, "_new_federation_client", new_client)
+
+    response = lib._federation_get("https://federation.example/path")
+
+    assert response.text == "ok"
+    assert [str(request.url) for request in captured] == [
+        "https://8.8.8.8/path",
+        "https://1.1.1.1/path",
+    ]
+    assert all(request.headers["Host"] == "federation.example" for request in captured)
+    assert all(request.extensions["sni_hostname"] == "federation.example" for request in captured)
+
+
 def test_federation_get_preserves_explicit_development_mode(monkeypatch, settings):
     """Allow explicit local HTTP destinations only in development mode."""
     settings.FEDERATION_FETCH_ALLOW_HTTP = True
@@ -162,12 +244,12 @@ def test_federation_get_preserves_explicit_development_mode(monkeypatch, setting
     )
     captured = []
 
-    def send(request):
+    def send(_client, request):
         """Capture the development request and return a successful response."""
         captured.append(request)
         return httpx.Response(200, text="ok", request=request)
 
-    monkeypatch.setattr(lib._HTTP_CLIENT, "send", send)
+    monkeypatch.setattr(httpx.Client, "send", send)
 
     response = lib._federation_get("http://ta:8080/fetch")
 

--- a/admin/tests/test_entitylib.py
+++ b/admin/tests/test_entitylib.py
@@ -54,7 +54,7 @@ def test_federation_get_pins_validated_public_address(monkeypatch, settings):
     assert len(captured) == 1  # redirects stay disabled
     assert str(captured[0].url) == "https://8.8.8.8/path?value=1"
     assert captured[0].headers["Host"] == "federation.example"
-    assert captured[0].extensions["sni_hostname"] == "federation.example"
+    assert captured[0].extensions["sni_hostname"] == b"federation.example"
 
 
 @pytest.mark.parametrize(

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -91,6 +91,7 @@ services:
     command: /app/docker-entrypoint.sh
     environment:
       - INSIDE_CONTAINER=true
+      - FEDERATION_FETCH_ALLOW_HTTP=true
       # MFA encryption key for TOTP secrets - generate a new key for production with:
       # python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
       # - MFA_ENCRYPTION_KEY=your-production-key-here

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -243,6 +243,8 @@ Admin Portal (Django)
      - Description
    * - ``INSIDE_CONTAINER``
      - Set to ``true`` when running in Docker
+   * - ``FEDERATION_FETCH_ALLOW_HTTP``
+     - Allow Admin federation fetches to use HTTP and private addresses. Development only; defaults to ``false``.
    * - ``DB_HOST``
      - PostgreSQL host (default: ``db``)
    * - ``DB_PORT``

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -697,6 +697,8 @@ Admin Portal (admin)
      - Description
    * - ``INSIDE_CONTAINER``
      - Set to ``true`` when running in Docker
+   * - ``FEDERATION_FETCH_ALLOW_HTTP``
+     - Allow Admin federation fetches to use HTTP and private addresses. Development only; defaults to ``false``.
    * - ``DB_HOST``
      - PostgreSQL host (default: ``db``)
    * - ``DB_PORT``

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use log::{debug, warn};
 use sha2::{Digest, Sha256};
 use std::fmt::Display;
 use std::net::IpAddr;
-use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, atomic::AtomicBool};
 
 use actix_web::{HttpRequest, HttpResponse, Responder, error, get, post, web};
 use actix_web_lab::extract::Query;
@@ -54,7 +54,21 @@ lazy_static! {
         .connect_timeout(Duration::from_secs(5))
         .timeout(Duration::from_secs(10))
         .pool_max_idle_per_host(10)
-        .redirect(reqwest::redirect::Policy::limited(5))
+        // Environment proxies resolve and connect outside our SSRF boundary.
+        .no_proxy()
+        // The resolver validates and returns the exact addresses reqwest uses,
+        // eliminating the validation-to-connection DNS rebinding window.
+        .dns_resolver(Arc::new(FederationDnsResolver))
+        .redirect(reqwest::redirect::Policy::custom(|attempt| {
+            if redirect_limit_exceeded(attempt.previous().len()) {
+                return attempt.error("too many redirects");
+            }
+            let allow_http = ALLOW_HTTP.load(std::sync::atomic::Ordering::Relaxed);
+            match validate_federation_destination(attempt.url(), allow_http) {
+                Ok(()) => attempt.follow(),
+                Err(message) => attempt.error(message),
+            }
+        }))
         .build()
         .expect("Failed to build HTTP client");
 }
@@ -108,6 +122,9 @@ pub fn ensure_signing_key_loaded() {
 
 /// Maximum response body size for outbound federation requests (2 MB).
 const MAX_RESPONSE_BYTES: usize = 2_097_152;
+
+/// Maximum redirects followed by the shared federation client.
+const MAX_FEDERATION_REDIRECTS: usize = 5;
 
 /// Maximum number of retries inside `get_query` before classifying the
 /// failure as a final transient error.
@@ -3316,23 +3333,157 @@ pub async fn get_entity_configruation_as_jwt(entity_id: &str) -> Result<String> 
     return get_query(&url).await;
 }
 
-/// Returns true if the IP address is in a private, loopback, or link-local range.
+/// Returns true if the IP address must not be contacted by a production
+/// federation fetch. Besides private ranges, this covers special-use,
+/// documentation, multicast, and IPv4-mapped IPv6 addresses.
 fn is_private_ip(ip: &IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => {
-            v4.is_loopback()       // 127.0.0.0/8
-            || v4.is_private()     // 10/8, 172.16/12, 192.168/16
-            || v4.is_link_local()  // 169.254/16
-            || v4.is_unspecified() // 0.0.0.0
-            || v4.is_broadcast() // 255.255.255.255
+            let [a, b, c, _] = v4.octets();
+            a == 0                         // current network / unspecified
+                || a == 10                 // private
+                || a == 127                // loopback
+                || (a == 100 && (64..=127).contains(&b)) // shared address space
+                || (a == 169 && b == 254)  // link-local
+                || (a == 172 && (16..=31).contains(&b)) // private
+                || (a == 192 && b == 0 && (c == 0 || c == 2)) // protocol + documentation
+                || (a == 192 && b == 88 && c == 99) // deprecated 6to4 relay
+                || (a == 192 && b == 168)  // private
+                || (a == 198 && (b == 18 || b == 19)) // benchmarking
+                || (a == 198 && b == 51 && c == 100) // documentation
+                || (a == 203 && b == 0 && c == 113) // documentation
+                || a >= 224 // multicast, reserved, broadcast
         }
         IpAddr::V6(v6) => {
+            let ietf_protocol_assignment =
+                ipv6_has_prefix(v6, std::net::Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 0), 23);
+            let globally_routable_ietf_exception = *v6
+                == std::net::Ipv6Addr::new(0x2001, 1, 0, 0, 0, 0, 0, 1)
+                || *v6 == std::net::Ipv6Addr::new(0x2001, 1, 0, 0, 0, 0, 0, 2)
+                || ipv6_has_prefix(v6, std::net::Ipv6Addr::new(0x2001, 3, 0, 0, 0, 0, 0, 0), 32)
+                || ipv6_has_prefix(
+                    v6,
+                    std::net::Ipv6Addr::new(0x2001, 4, 0x112, 0, 0, 0, 0, 0),
+                    48,
+                )
+                || ipv6_has_prefix(
+                    v6,
+                    std::net::Ipv6Addr::new(0x2001, 0x20, 0, 0, 0, 0, 0, 0),
+                    28,
+                )
+                || ipv6_has_prefix(
+                    v6,
+                    std::net::Ipv6Addr::new(0x2001, 0x30, 0, 0, 0, 0, 0, 0),
+                    28,
+                );
             v6.is_loopback()       // ::1
             || v6.is_unspecified() // ::
+            || v6.to_ipv4().is_some_and(|v4| is_private_ip(&IpAddr::V4(v4)))
+            || ipv6_has_prefix(v6, std::net::Ipv6Addr::new(0x64, 0xff9b, 1, 0, 0, 0, 0, 0), 48)
+            || ipv6_has_prefix(v6, std::net::Ipv6Addr::new(0x100, 0, 0, 0, 0, 0, 0, 0), 64)
+            || (ietf_protocol_assignment && !globally_routable_ietf_exception)
+            || ipv6_has_prefix(v6, std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0), 32)
+            || ipv6_has_prefix(v6, std::net::Ipv6Addr::new(0x2002, 0, 0, 0, 0, 0, 0, 0), 16)
+            || ipv6_has_prefix(v6, std::net::Ipv6Addr::new(0x3fff, 0, 0, 0, 0, 0, 0, 0), 20)
+            || ipv6_has_prefix(v6, std::net::Ipv6Addr::new(0x5f00, 0, 0, 0, 0, 0, 0, 0), 16)
             // unique local (fc00::/7) and link-local (fe80::/10)
             || (v6.segments()[0] & 0xfe00) == 0xfc00
             || (v6.segments()[0] & 0xffc0) == 0xfe80
+            || (v6.segments()[0] & 0xff00) == 0xff00 // multicast
+            || (v6.segments()[0] == 0x2001 && v6.segments()[1] == 0x0db8) // documentation
         }
+    }
+}
+
+fn ipv6_has_prefix(
+    address: &std::net::Ipv6Addr,
+    network: std::net::Ipv6Addr,
+    prefix_len: u32,
+) -> bool {
+    let mask = u128::MAX << (128 - prefix_len);
+    u128::from(*address) & mask == u128::from(network) & mask
+}
+
+/// Reqwest includes the initial request in `Attempt::previous()`. Matching
+/// `Policy::limited(5)` therefore means rejecting only once the count exceeds
+/// five, not when it reaches five.
+fn redirect_limit_exceeded(previous_count: usize) -> bool {
+    previous_count > MAX_FEDERATION_REDIRECTS
+}
+
+/// Synchronous URL checks used for both initial URLs and every redirect.
+/// DNS names are checked by `FederationDnsResolver` at connection time.
+fn validate_federation_destination(
+    parsed: &url::Url,
+    allow_http: bool,
+) -> std::result::Result<(), String> {
+    match parsed.scheme() {
+        "https" => {}
+        "http" if allow_http => {}
+        scheme => return Err(format!("Blocked scheme '{scheme}' - only HTTPS allowed")),
+    }
+
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("Federation URLs must not contain credentials".to_string());
+    }
+    if parsed.fragment().is_some() {
+        return Err("Federation URLs must not contain fragments".to_string());
+    }
+
+    let host = parsed
+        .host()
+        .ok_or_else(|| "Federation URL has no host".to_string())?;
+    if !allow_http {
+        let literal = match host {
+            url::Host::Ipv4(ip) => Some(IpAddr::V4(ip)),
+            url::Host::Ipv6(ip) => Some(IpAddr::V6(ip)),
+            url::Host::Domain(_) => None,
+        };
+        if literal.as_ref().is_some_and(is_private_ip) {
+            return Err(format!(
+                "Blocked request to private/internal IP {}",
+                literal.expect("literal address is present")
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Resolver installed directly on reqwest so validated addresses are the
+/// addresses used by the connection, including after redirects.
+#[derive(Debug)]
+struct FederationDnsResolver;
+
+impl reqwest::dns::Resolve for FederationDnsResolver {
+    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        let host = name.as_str().to_owned();
+        Box::pin(async move {
+            let resolved: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host.as_str(), 0))
+                .await
+                .map_err(|error| {
+                    Box::new(std::io::Error::other(format!(
+                        "DNS resolution failed for '{host}': {error}"
+                    ))) as Box<dyn StdError + Send + Sync>
+                })?
+                .collect();
+            if resolved.is_empty() {
+                return Err(Box::new(std::io::Error::other(format!(
+                    "DNS resolution returned no addresses for '{host}'"
+                ))) as Box<dyn StdError + Send + Sync>);
+            }
+            if !ALLOW_HTTP.load(std::sync::atomic::Ordering::Relaxed)
+                && let Some(blocked) = resolved.iter().find(|addr| is_private_ip(&addr.ip()))
+            {
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    format!(
+                        "Blocked request to private/internal IP {} (resolved from '{host}')",
+                        blocked.ip()
+                    ),
+                )) as Box<dyn StdError + Send + Sync>);
+            }
+            Ok(Box::new(resolved.into_iter()) as reqwest::dns::Addrs)
+        })
     }
 }
 
@@ -3389,28 +3540,20 @@ async fn validate_federation_url(url_str: &str, allow_http: bool) -> Result<()> 
         )))
     })?;
 
-    // 1. Scheme check
-    match parsed.scheme() {
-        "https" => {}
-        "http" if allow_http => {}
-        scheme => {
-            return Err(anyhow::Error::new(FetchError::permanent(format!(
-                "Blocked scheme '{scheme}' in URL '{url_str}' — only HTTPS allowed"
-            ))));
-        }
-    }
+    validate_federation_destination(&parsed, allow_http).map_err(|message| {
+        anyhow::Error::new(FetchError::permanent(format!(
+            "{message} in URL '{url_str}'"
+        )))
+    })?;
 
     // In development mode, skip DNS/IP validation
     if allow_http {
         return Ok(());
     }
 
-    // 2. Must have a host
-    let host = parsed.host_str().ok_or_else(|| {
-        anyhow::Error::new(FetchError::permanent(format!(
-            "URL '{url_str}' has no host"
-        )))
-    })?;
+    let host = parsed
+        .host_str()
+        .expect("destination validation requires a host");
 
     // 3. Resolve DNS and check all IPs
     let port = parsed.port_or_known_default().unwrap_or(443);
@@ -3451,7 +3594,12 @@ async fn validate_federation_url(url_str: &str, allow_http: bool) -> Result<()> 
 /// `get_query`. Used to call external trust mark issuers' `/trust_mark_status` endpoint.
 pub async fn post_form_query(url: &str, form: &[(&str, &str)]) -> Result<String> {
     validate_federation_url(url, ALLOW_HTTP.load(std::sync::atomic::Ordering::Relaxed)).await?;
-    let response = HTTP_CLIENT.post(url).form(form).send().await?;
+    let response = HTTP_CLIENT
+        .post(url)
+        .form(form)
+        .send()
+        .await
+        .map_err(|error| classify_transport_error(url, error))?;
     if !response.status().is_success() {
         bail!("POST to '{}' returned status {}", url, response.status());
     }
@@ -3556,12 +3704,11 @@ pub async fn get_query(url: &str) -> Result<String> {
 /// participate in the retry loop.
 async fn try_one_fetch(url: &str) -> Result<String> {
     validate_federation_url(url, ALLOW_HTTP.load(std::sync::atomic::Ordering::Relaxed)).await?;
-    let response = HTTP_CLIENT.get(url).send().await.map_err(|e| {
-        anyhow::Error::new(FetchError::transient(
-            None,
-            format!("transport error fetching '{url}': {e}"),
-        ))
-    })?;
+    let response = HTTP_CLIENT
+        .get(url)
+        .send()
+        .await
+        .map_err(|error| classify_transport_error(url, error))?;
     let status = response.status();
     if status.is_success() {
         return read_response_body(url, response).await;
@@ -3581,6 +3728,29 @@ async fn try_one_fetch(url: &str) -> Result<String> {
     Err(anyhow::Error::new(FetchError::permanent(format!(
         "HTTP {status} from '{url}'"
     ))))
+}
+
+/// Preserve retry classification while ensuring a redirect-policy or resolver
+/// SSRF denial is never treated as a transient upstream failure.
+fn classify_transport_error(url: &str, error: reqwest::Error) -> anyhow::Error {
+    let message = format!("transport error fetching '{url}': {error}");
+    let mut source: Option<&(dyn StdError + 'static)> = Some(&error);
+    let mut policy_denial = error.is_redirect();
+    while let Some(current) = source {
+        if current
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io_error| io_error.kind() == std::io::ErrorKind::PermissionDenied)
+        {
+            policy_denial = true;
+            break;
+        }
+        source = current.source();
+    }
+    if policy_denial {
+        anyhow::Error::new(FetchError::permanent(message))
+    } else {
+        anyhow::Error::new(FetchError::transient(None, message))
+    }
 }
 
 /// Drain a successful response into a UTF-8 string, enforcing the body cap.
@@ -4904,6 +5074,9 @@ mod ssrf_tests {
         assert!(is_private_ip(&"0.0.0.0".parse().unwrap()));
         // Broadcast
         assert!(is_private_ip(&"255.255.255.255".parse().unwrap()));
+        assert!(is_private_ip(&"100.64.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"198.51.100.1".parse().unwrap()));
+        assert!(is_private_ip(&"224.0.0.1".parse().unwrap()));
         // Public IPs should pass
         assert!(!is_private_ip(&"8.8.8.8".parse().unwrap()));
         assert!(!is_private_ip(&"1.1.1.1".parse().unwrap()));
@@ -4921,9 +5094,61 @@ mod ssrf_tests {
         assert!(is_private_ip(&"fd00::1".parse().unwrap()));
         // Link-local (fe80::/10)
         assert!(is_private_ip(&"fe80::1".parse().unwrap()));
+        assert!(is_private_ip(&"::ffff:127.0.0.1".parse().unwrap()));
+        assert!(is_private_ip(&"ff02::1".parse().unwrap()));
+        assert!(is_private_ip(&"2001:db8::1".parse().unwrap()));
+        assert!(is_private_ip(&"64:ff9b:1::1".parse().unwrap()));
+        assert!(is_private_ip(&"100::1".parse().unwrap()));
+        assert!(is_private_ip(&"2001:2::1".parse().unwrap()));
+        assert!(is_private_ip(&"2002::1".parse().unwrap()));
+        assert!(is_private_ip(&"3fff::1".parse().unwrap()));
+        assert!(is_private_ip(&"5f00::1".parse().unwrap()));
         // Public IPv6
-        assert!(!is_private_ip(&"2001:db8::1".parse().unwrap()));
+        assert!(!is_private_ip(&"2001:3::1".parse().unwrap()));
         assert!(!is_private_ip(&"2607:f8b0:4004:800::200e".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_redirect_limit_matches_reqwest_limited_five() {
+        assert!(!redirect_limit_exceeded(5));
+        assert!(redirect_limit_exceeded(6));
+    }
+
+    #[test]
+    fn test_redirect_destination_rejects_ssrf_bypasses() {
+        for target in [
+            "http://example.com/next",
+            "https://127.0.0.1/internal",
+            "https://[::ffff:127.0.0.1]/internal",
+            "https://user@example.com/next",
+            "https://example.com/next#fragment",
+        ] {
+            let parsed = url::Url::parse(target).unwrap();
+            assert!(
+                validate_federation_destination(&parsed, false).is_err(),
+                "redirect target should be blocked: {target}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_redirect_destination_preserves_development_mode() {
+        for target in ["http://127.0.0.1/next", "https://[::1]/next"] {
+            let parsed = url::Url::parse(target).unwrap();
+            assert!(validate_federation_destination(&parsed, true).is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_connection_resolver_rejects_internal_dns() {
+        use reqwest::dns::Resolve;
+
+        let name = "localhost".parse().unwrap();
+        let error = match FederationDnsResolver.resolve(name).await {
+            Ok(_) => panic!("localhost should not pass the production resolver"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("private/internal"));
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3355,6 +3355,10 @@ fn is_private_ip(ip: &IpAddr) -> bool {
                 || a >= 224 // multicast, reserved, broadcast
         }
         IpAddr::V6(v6) => {
+            let public_nat64_destination =
+                nat64_embedded_ipv4(v6).is_some_and(|v4| !is_private_ip(&IpAddr::V4(v4)));
+            let global_unicast = public_nat64_destination
+                || ipv6_has_prefix(v6, std::net::Ipv6Addr::new(0x2000, 0, 0, 0, 0, 0, 0, 0), 3);
             let ietf_protocol_assignment =
                 ipv6_has_prefix(v6, std::net::Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 0), 23);
             let globally_routable_ietf_exception = *v6
@@ -3376,7 +3380,8 @@ fn is_private_ip(ip: &IpAddr) -> bool {
                     std::net::Ipv6Addr::new(0x2001, 0x30, 0, 0, 0, 0, 0, 0),
                     28,
                 );
-            v6.is_loopback()       // ::1
+            !global_unicast
+            || v6.is_loopback()       // ::1
             || v6.is_unspecified() // ::
             || v6.to_ipv4().is_some_and(|v4| is_private_ip(&IpAddr::V4(v4)))
             || ipv6_has_prefix(v6, std::net::Ipv6Addr::new(0x64, 0xff9b, 1, 0, 0, 0, 0, 0), 48)
@@ -3395,6 +3400,7 @@ fn is_private_ip(ip: &IpAddr) -> bool {
     }
 }
 
+/// Returns whether an IPv6 address belongs to the supplied network prefix.
 fn ipv6_has_prefix(
     address: &std::net::Ipv6Addr,
     network: std::net::Ipv6Addr,
@@ -3402,6 +3408,22 @@ fn ipv6_has_prefix(
 ) -> bool {
     let mask = u128::MAX << (128 - prefix_len);
     u128::from(*address) & mask == u128::from(network) & mask
+}
+
+/// Extracts the IPv4 destination encoded by the globally reachable NAT64
+/// well-known prefix. The local-use `64:ff9b:1::/48` prefix is excluded.
+fn nat64_embedded_ipv4(address: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
+    if !ipv6_has_prefix(
+        address,
+        std::net::Ipv6Addr::new(0x64, 0xff9b, 0, 0, 0, 0, 0, 0),
+        96,
+    ) {
+        return None;
+    }
+    let octets = address.octets();
+    Some(std::net::Ipv4Addr::new(
+        octets[12], octets[13], octets[14], octets[15],
+    ))
 }
 
 /// Reqwest includes the initial request in `Attempt::previous()`. Matching
@@ -3455,6 +3477,7 @@ fn validate_federation_destination(
 struct FederationDnsResolver;
 
 impl reqwest::dns::Resolve for FederationDnsResolver {
+    /// Resolves a host and rejects every non-public address before connection.
     fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
         let host = name.as_str().to_owned();
         Box::pin(async move {
@@ -5064,18 +5087,24 @@ mod ssrf_tests {
         assert!(is_private_ip(&"2002::1".parse().unwrap()));
         assert!(is_private_ip(&"3fff::1".parse().unwrap()));
         assert!(is_private_ip(&"5f00::1".parse().unwrap()));
+        assert!(is_private_ip(&"4000::1".parse().unwrap()));
+        assert!(is_private_ip(&"fec0::1".parse().unwrap()));
+        assert!(is_private_ip(&"64:ff9b::7f00:1".parse().unwrap()));
         // Public IPv6
         assert!(!is_private_ip(&"2001:3::1".parse().unwrap()));
         assert!(!is_private_ip(&"2607:f8b0:4004:800::200e".parse().unwrap()));
+        assert!(!is_private_ip(&"64:ff9b::5db8:d822".parse().unwrap()));
     }
 
     #[test]
+    /// Confirms the custom redirect policy preserves reqwest's five-hop limit.
     fn test_redirect_limit_matches_reqwest_limited_five() {
         assert!(!redirect_limit_exceeded(5));
         assert!(redirect_limit_exceeded(6));
     }
 
     #[test]
+    /// Rejects redirect destinations that can bypass the federation SSRF policy.
     fn test_redirect_destination_rejects_ssrf_bypasses() {
         for target in [
             "http://example.com/next",
@@ -5093,6 +5122,7 @@ mod ssrf_tests {
     }
 
     #[test]
+    /// Retains the explicit private-address exception used by development.
     fn test_redirect_destination_preserves_development_mode() {
         for target in ["http://127.0.0.1/next", "https://[::1]/next"] {
             let parsed = url::Url::parse(target).unwrap();
@@ -5101,6 +5131,7 @@ mod ssrf_tests {
     }
 
     #[tokio::test]
+    /// Rejects internal DNS answers at reqwest's connection boundary.
     async fn test_connection_resolver_rejects_internal_dns() {
         use reqwest::dns::Resolve;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3430,7 +3430,7 @@ fn nat64_embedded_ipv4(address: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Add
 /// `Policy::limited(5)` therefore means rejecting only once the count exceeds
 /// five, not when it reaches five.
 fn redirect_limit_exceeded(previous_count: usize) -> bool {
-    previous_count >= MAX_FEDERATION_REDIRECTS
+    previous_count > MAX_FEDERATION_REDIRECTS
 }
 
 /// Synchronous URL checks used for both initial URLs and every redirect.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3430,7 +3430,7 @@ fn nat64_embedded_ipv4(address: &std::net::Ipv6Addr) -> Option<std::net::Ipv4Add
 /// `Policy::limited(5)` therefore means rejecting only once the count exceeds
 /// five, not when it reaches five.
 fn redirect_limit_exceeded(previous_count: usize) -> bool {
-    previous_count > MAX_FEDERATION_REDIRECTS
+    previous_count >= MAX_FEDERATION_REDIRECTS
 }
 
 /// Synchronous URL checks used for both initial URLs and every redirect.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3523,17 +3523,18 @@ fn validate_entity_type(etype: &str) -> Result<(), &'static str> {
     }
 }
 
-/// Validates a URL for federation use: HTTPS scheme, no private IPs.
-/// When `allow_http` is true (development mode), all checks are relaxed.
-/// SSRF gate + scheme allowlist for outbound federation URLs.
+/// Validates URL-level federation policy before a request is built.
+/// Development mode relaxes only the HTTPS and private-address restrictions;
+/// credentials, fragments, malformed URLs, and missing hosts remain blocked.
+/// DNS names are validated and pinned by `FederationDnsResolver` at the
+/// connection boundary, avoiding a second preflight lookup.
 ///
 /// Failures are classified as `FetchError`:
-/// * URL parse / scheme block / no host / private-IP block are *permanent*
+/// * URL parse / scheme block / no host / literal private-IP block are *permanent*
 ///   — no amount of retrying changes the answer, and propagating them as
 ///   transient would let callers burn retries on a policy denial.
-/// * DNS resolution failure (incl. empty resolution) is *transient* — a
-///   resolver hiccup is exactly the kind of thing §10.5 says to retry.
-async fn validate_federation_url(url_str: &str, allow_http: bool) -> Result<()> {
+/// Resolver failures are classified at the transport boundary.
+fn validate_federation_url(url_str: &str, allow_http: bool) -> Result<()> {
     let parsed = url::Url::parse(url_str).map_err(|e| {
         anyhow::Error::new(FetchError::permanent(format!(
             "Invalid URL '{url_str}': {e}"
@@ -3546,46 +3547,6 @@ async fn validate_federation_url(url_str: &str, allow_http: bool) -> Result<()> 
         )))
     })?;
 
-    // In development mode, skip DNS/IP validation
-    if allow_http {
-        return Ok(());
-    }
-
-    let host = parsed
-        .host_str()
-        .expect("destination validation requires a host");
-
-    // 3. Resolve DNS and check all IPs
-    let port = parsed.port_or_known_default().unwrap_or(443);
-    let addr = format!("{}:{}", host, port);
-    let resolved: Vec<std::net::SocketAddr> = tokio::net::lookup_host(&addr)
-        .await
-        .map_err(|e| {
-            // DNS failures (incl. SERVFAIL, timeout, no nameservers) are
-            // transient per §10.5.
-            anyhow::Error::new(FetchError::transient(
-                None,
-                format!("DNS resolution failed for '{host}': {e}"),
-            ))
-        })?
-        .collect();
-
-    if resolved.is_empty() {
-        return Err(anyhow::Error::new(FetchError::transient(
-            None,
-            format!("DNS resolution returned no addresses for '{host}'"),
-        )));
-    }
-
-    for sock_addr in &resolved {
-        if is_private_ip(&sock_addr.ip()) {
-            return Err(anyhow::Error::new(FetchError::permanent(format!(
-                "Blocked request to private/internal IP {} (resolved from '{host}')",
-                sock_addr.ip()
-            ))));
-        }
-    }
-
     Ok(())
 }
 
@@ -3593,7 +3554,7 @@ async fn validate_federation_url(url_str: &str, allow_http: bool) -> Result<()> 
 /// shared HTTP client (timeouts/redirect limit/pool), and `MAX_RESPONSE_BYTES` cap as
 /// `get_query`. Used to call external trust mark issuers' `/trust_mark_status` endpoint.
 pub async fn post_form_query(url: &str, form: &[(&str, &str)]) -> Result<String> {
-    validate_federation_url(url, ALLOW_HTTP.load(std::sync::atomic::Ordering::Relaxed)).await?;
+    validate_federation_url(url, ALLOW_HTTP.load(std::sync::atomic::Ordering::Relaxed))?;
     let response = HTTP_CLIENT
         .post(url)
         .form(form)
@@ -3700,10 +3661,10 @@ pub async fn get_query(url: &str) -> Result<String> {
 /// One attempt of the get_query pipeline: SSRF gate -> HTTP request ->
 /// body drain. Returns a typed `FetchError` (wrapped in `anyhow::Error`)
 /// so the retry loop can decide permanent-vs-transient. Body-read failures
-/// and DNS hiccups inside the SSRF gate both surface as transient and
-/// participate in the retry loop.
+/// and DNS hiccups from the connection-time resolver both surface as
+/// transient and participate in the retry loop.
 async fn try_one_fetch(url: &str) -> Result<String> {
-    validate_federation_url(url, ALLOW_HTTP.load(std::sync::atomic::Ordering::Relaxed)).await?;
+    validate_federation_url(url, ALLOW_HTTP.load(std::sync::atomic::Ordering::Relaxed))?;
     let response = HTTP_CLIENT
         .get(url)
         .send()
@@ -5151,9 +5112,9 @@ mod ssrf_tests {
         assert!(error.to_string().contains("private/internal"));
     }
 
-    #[tokio::test]
-    async fn test_validate_rejects_http() {
-        let result = validate_federation_url("http://example.com/foo", false).await;
+    #[test]
+    fn test_validate_rejects_http() {
+        let result = validate_federation_url("http://example.com/foo", false);
         assert!(result.is_err());
         assert!(
             result
@@ -5163,17 +5124,17 @@ mod ssrf_tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_validate_allows_http_when_configured() {
+    #[test]
+    fn test_validate_allows_http_when_configured() {
         // With allow_http=true, HTTP scheme should not be rejected
-        let result = validate_federation_url("http://example.com/foo", true).await;
-        // Should succeed (allow_http skips all checks after scheme)
+        let result = validate_federation_url("http://example.com/foo", true);
+        // Should succeed (development mode permits HTTP destinations)
         assert!(result.is_ok());
     }
 
-    #[tokio::test]
-    async fn test_validate_rejects_non_http_schemes() {
-        let result = validate_federation_url("ftp://example.com/foo", false).await;
+    #[test]
+    fn test_validate_rejects_non_http_schemes() {
+        let result = validate_federation_url("ftp://example.com/foo", false);
         assert!(result.is_err());
         assert!(
             result
@@ -5182,28 +5143,27 @@ mod ssrf_tests {
                 .contains("only HTTPS allowed")
         );
 
-        let result = validate_federation_url("file:///etc/passwd", false).await;
+        let result = validate_federation_url("file:///etc/passwd", false);
         assert!(result.is_err());
     }
 
-    #[tokio::test]
-    async fn test_validate_rejects_private_ips() {
-        // localhost resolves to 127.0.0.1
-        let result = validate_federation_url("https://127.0.0.1/foo", false).await;
+    #[test]
+    fn test_validate_rejects_private_ips() {
+        let result = validate_federation_url("https://127.0.0.1/foo", false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("private/internal"));
     }
 
-    #[tokio::test]
-    async fn test_validate_allows_private_ips_in_dev_mode() {
+    #[test]
+    fn test_validate_allows_private_ips_in_dev_mode() {
         // With allow_http=true (dev mode), private IPs should be allowed
-        let result = validate_federation_url("https://127.0.0.1/foo", true).await;
+        let result = validate_federation_url("https://127.0.0.1/foo", true);
         assert!(result.is_ok());
     }
 
-    #[tokio::test]
-    async fn test_validate_rejects_invalid_url() {
-        let result = validate_federation_url("not-a-url", false).await;
+    #[test]
+    fn test_validate_rejects_invalid_url() {
+        let result = validate_federation_url("not-a-url", false);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Invalid URL"));
     }


### PR DESCRIPTION
Validate redirect targets and pin DNS addresses for Rust federation requests. Route Admin federation requests through a safe HTTP client that blocks private destinations, redirects, proxies, credentials, and fragment-based path truncation.

Keep private HTTP access behind an explicit development setting and add regression tests and configuration documentation.