### PR TITLE
fix: protect signed claims from additional claim overrides

### DIFF
--- a/admin/common/claims.py
+++ b/admin/common/claims.py
@@ -1,0 +1,40 @@
+from collections.abc import Collection
+from typing import Any
+
+
+SIGNED_STATEMENT_PROTECTED_CLAIMS = frozenset({"iss", "sub", "exp", "iat"})
+TRUST_MARK_PROTECTED_CLAIMS = SIGNED_STATEMENT_PROTECTED_CLAIMS | {"trust_mark_type"}
+SUBORDINATE_PROTECTED_CLAIMS = SIGNED_STATEMENT_PROTECTED_CLAIMS | {
+    "jwks",
+    "metadata",
+    "metadata_policy",
+}
+
+
+def validate_additional_claims(
+    additional_claims: dict[str, Any] | None,
+    protected_claims: Collection[str],
+) -> dict[str, Any] | None:
+    """Reject additional claims that could replace authoritative signed claims."""
+    if additional_claims is None:
+        return None
+
+    conflicts = sorted(additional_claims.keys() & set(protected_claims))
+    if conflicts:
+        names = ", ".join(conflicts)
+        raise ValueError(f"additional_claims contains protected claims: {names}")
+    return additional_claims
+
+
+def validate_trust_mark_additional_claims(
+    additional_claims: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Validate extension claims for a Trust Mark."""
+    return validate_additional_claims(additional_claims, TRUST_MARK_PROTECTED_CLAIMS)
+
+
+def validate_subordinate_additional_claims(
+    additional_claims: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Validate extension claims for a subordinate statement."""
+    return validate_additional_claims(additional_claims, SUBORDINATE_PROTECTED_CLAIMS)

--- a/admin/common/claims.py
+++ b/admin/common/claims.py
@@ -12,12 +12,14 @@ SUBORDINATE_PROTECTED_CLAIMS = SIGNED_STATEMENT_PROTECTED_CLAIMS | {
 
 
 def validate_additional_claims(
-    additional_claims: dict[str, Any] | None,
+    additional_claims: Any,
     protected_claims: Collection[str],
 ) -> dict[str, Any] | None:
     """Reject additional claims that could replace authoritative signed claims."""
     if additional_claims is None:
         return None
+    if not isinstance(additional_claims, dict):
+        raise ValueError("additional_claims must be a JSON object")
 
     conflicts = sorted(additional_claims.keys() & set(protected_claims))
     if conflicts:
@@ -27,14 +29,14 @@ def validate_additional_claims(
 
 
 def validate_trust_mark_additional_claims(
-    additional_claims: dict[str, Any] | None,
+    additional_claims: Any,
 ) -> dict[str, Any] | None:
     """Validate extension claims for a Trust Mark."""
     return validate_additional_claims(additional_claims, TRUST_MARK_PROTECTED_CLAIMS)
 
 
 def validate_subordinate_additional_claims(
-    additional_claims: dict[str, Any] | None,
+    additional_claims: Any,
 ) -> dict[str, Any] | None:
     """Validate extension claims for a subordinate statement."""
     return validate_additional_claims(additional_claims, SUBORDINATE_PROTECTED_CLAIMS)

--- a/admin/entities/admin.py
+++ b/admin/entities/admin.py
@@ -1,5 +1,35 @@
+from typing import Any
+
+from django import forms
 from django.contrib import admin
+from django.core.exceptions import ValidationError
+
+from common.claims import validate_subordinate_additional_claims
 
 from .models import Subordinate
 
-admin.site.register(Subordinate)
+
+class SubordinateAdminForm(forms.ModelForm):
+    """Validate subordinate extension claims submitted through Django admin."""
+
+    class Meta:
+        model = Subordinate
+        fields = "__all__"
+
+    def clean_additional_claims(self) -> dict[str, Any] | None:
+        """Reject claims controlled by the Trust Anchor."""
+        try:
+            return validate_subordinate_additional_claims(
+                self.cleaned_data.get("additional_claims")
+            )
+        except ValueError as error:
+            raise ValidationError(str(error)) from error
+
+
+class SubordinateAdmin(admin.ModelAdmin):
+    """Admin configuration for subordinates."""
+
+    form = SubordinateAdminForm
+
+
+admin.site.register(Subordinate, SubordinateAdmin)

--- a/admin/entities/lib.py
+++ b/admin/entities/lib.py
@@ -16,6 +16,7 @@ from oidfpolicy import apply_policy, merge_policies
 from pydantic import BaseModel
 from redis import Redis
 
+from common.claims import validate_subordinate_additional_claims
 from common.signing import create_signed_jwt
 
 INSIDE_CONTAINER = os.environ.get("INSIDE_CONTAINER")
@@ -323,17 +324,16 @@ def create_subordinate_statement(
     forced_metadata: dict[str, Any] | None,
     additional_claims: dict[str, Any] | None = None,
 ) -> str:
-    """Creates a signed Subordinate Statement"""
-    # This is the data we care for now
-    sub_data = {"iss": settings.TA_DOMAIN}
+    """Create a signed subordinate statement with authoritative core claims."""
+    additional_claims = validate_subordinate_additional_claims(additional_claims)
+
+    # Merge extensions first, then set claims that are authoritative for this issuer.
+    sub_data = dict(additional_claims or {})
+    sub_data["iss"] = settings.TA_DOMAIN
     sub_data["sub"] = entityid
     # Add any forced metadata if available
     if forced_metadata is not None:
         sub_data["metadata"] = forced_metadata
-
-    # Any non-mandatory additional claims will be added in the subordinate statement.
-    if additional_claims:
-        sub_data.update(additional_claims)
 
     # This is the metadata policy of TA defined in the settings.py
     if settings.POLICY_DOCUMENT.get("metadata_policy", {}):

--- a/admin/inmoradmin/api.py
+++ b/admin/inmoradmin/api.py
@@ -24,10 +24,15 @@ from entities.lib import (
 from entities.models import Subordinate
 from ninja import NinjaAPI, Router, Schema
 from ninja.pagination import LimitOffsetPagination, paginate
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import AfterValidator, BaseModel, BeforeValidator, Field
 from redis.client import Redis
 from trustmarks.lib import add_trustmark, get_expiry
 from trustmarks.models import TrustMark, TrustMarkType
+
+from common.claims import (
+    validate_subordinate_additional_claims,
+    validate_trust_mark_additional_claims,
+)
 
 from .auth import auth_router, combined_auth
 
@@ -102,7 +107,10 @@ class TrustMarkSchema(Schema):
     valid_for: int | None = None
     renewal_time: int | None = None
     active: bool | None = None
-    additional_claims: dict[str, Any] | None = None
+    additional_claims: Annotated[
+        dict[str, Any] | None,
+        AfterValidator(validate_trust_mark_additional_claims),
+    ] = None
 
 
 class TrustMarkOutSchema(Schema):
@@ -137,7 +145,9 @@ class TrustMarkUpdateSchema(Schema):
     ] = None
     active: Annotated[bool | None, Field(description="If the TrustMarkType is active.")] = None
     additional_claims: Annotated[
-        dict[str, Any] | None, Field(description="Current additional claims for the TrustMark.")
+        dict[str, Any] | None,
+        AfterValidator(validate_trust_mark_additional_claims),
+        Field(description="Current additional claims for the TrustMark."),
     ] = None
 
 
@@ -183,6 +193,7 @@ class EntityTypeSchema(Schema):
     active: bool | None = True
     additional_claims: Annotated[
         dict[str, Any] | None,
+        AfterValidator(validate_subordinate_additional_claims),
         Field(description="Additional claims for an Entity which shows in subordinate statement."),
     ] = None
 
@@ -197,6 +208,7 @@ class EntityTypeUpdateSchema(Schema):
     active: bool | None = True
     additional_claims: Annotated[
         dict[str, Any] | None,
+        AfterValidator(validate_subordinate_additional_claims),
         Field(description="Additional claims for an Entity which shows in subordinate statement."),
     ] = None
 

--- a/admin/spec.md
+++ b/admin/spec.md
@@ -17,6 +17,10 @@ This document describes how the inmor admin module implements the [OpenID Federa
 | `ref` | OPTIONAL | ✅ Via `additional_claims` |
 | `delegation` | OPTIONAL | ✅ Via `additional_claims` |
 
+`additional_claims` accepts extension claims such as `logo_uri`, `ref`, and `delegation`. It
+rejects `iss`, `sub`, `iat`, `exp`, and `trust_mark_type`, which are controlled by the Trust Mark
+issuer.
+
 ### Trust Mark JWT Type Header
 
 Per Section 7:
@@ -79,6 +83,10 @@ token_data = create_signed_jwt(sub_data, key, "entity-statement+jwt")
 | `constraints` | OPTIONAL | ✅ Via `additional_claims` |
 | `metadata_policy_crit` | OPTIONAL | ✅ Via `additional_claims` |
 | `source_endpoint` | OPTIONAL | ✅ Via `additional_claims` |
+
+`additional_claims` accepts extension claims such as `constraints`, `metadata_policy_crit`, and
+`source_endpoint`. It rejects the issuer-controlled `iss`, `sub`, `iat`, `exp`, `jwks`, `metadata`,
+and `metadata_policy` claims.
 
 ### Subordinate Storage
 

--- a/admin/tests/test_api.py
+++ b/admin/tests/test_api.py
@@ -288,6 +288,30 @@ def test_trustmark_create_with_additional_claims(auth_client: Client, loadredis)
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("protected_claim", ("iss", "sub", "iat", "exp", "trust_mark_type"))
+def test_trustmark_create_rejects_protected_additional_claim(auth_client, protected_claim):
+    """Reject Trust Mark claim collisions before creating a database record."""
+    from trustmarks.models import TrustMark
+
+    domain = f"https://blocked-{protected_claim}.example"
+    response = auth_client.post(
+        "/api/v1/trustmarks",
+        data=json.dumps(
+            {
+                "tmt": 2,
+                "domain": domain,
+                "additional_claims": {protected_claim: "attacker-controlled"},
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 422
+    assert protected_claim in response.content.decode()
+    assert not TrustMark.objects.filter(domain=domain).exists()
+
+
+@pytest.mark.django_db
 def test_trustmark_update_additional_claims(auth_client: Client, loadredis):
     """Test updating a trustmark's additional_claims and verify changes in JWT payload."""
     domain = "https://fakerp2.labb.sunet.se"
@@ -335,6 +359,25 @@ def test_trustmark_update_additional_claims(auth_client: Client, loadredis):
     payload = get_payload(jwt_token)
     # Verify the claim is removed from the JWT payload
     assert payload.get("ref") is None
+
+
+@pytest.mark.django_db
+def test_trustmark_update_rejects_protected_claim_without_changes(auth_client):
+    """Leave an existing Trust Mark unchanged when an update collides with `exp`."""
+    from trustmarks.models import TrustMark
+
+    trust_mark = TrustMark.objects.get(id=1)
+    original = (trust_mark.additional_claims, trust_mark.mark, trust_mark.expire_at)
+
+    response = auth_client.put(
+        f"/api/v1/trustmarks/{trust_mark.id}",
+        data=json.dumps({"additional_claims": {"exp": 4102444800}}),
+        content_type="application/json",
+    )
+
+    trust_mark.refresh_from_db()
+    assert response.status_code == 422
+    assert (trust_mark.additional_claims, trust_mark.mark, trust_mark.expire_at) == original
 
 
 @pytest.mark.django_db
@@ -561,6 +604,35 @@ def test_add_subordinate_with_key(auth_client: Client, loadredis, clean_subordin
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "protected_claim",
+    ("iss", "sub", "iat", "exp", "jwks", "metadata", "metadata_policy"),
+)
+def test_subordinate_create_rejects_protected_additional_claim(auth_client, protected_claim):
+    """Reject subordinate claim collisions before fetching or persisting the entity."""
+    from entities.models import Subordinate
+
+    entity_id = f"https://blocked-{protected_claim}.example"
+    response = auth_client.post(
+        "/api/v1/subordinates",
+        data=json.dumps(
+            {
+                "entityid": entity_id,
+                "metadata": {},
+                "forced_metadata": {},
+                "jwks": {},
+                "additional_claims": {protected_claim: "attacker-controlled"},
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert response.status_code == 422
+    assert protected_claim in response.content.decode()
+    assert not Subordinate.objects.filter(entityid=entity_id).exists()
+
+
+@pytest.mark.django_db
 def test_add_subordinate_with_key_twice(auth_client: Client, loadredis, clean_subordinate):  # type: ignore
     "Tests adding subordinate"
     with open(os.path.join(data_dir, "fakerp0_metadata_without_key.json")) as fobj:
@@ -729,6 +801,33 @@ def test_update_subordinate_autorenew(auth_client: Client, loadredis, clean_subo
     assert response.status_code == 200
     updated = response.json()
     assert updated.get("autorenew") is False
+
+
+@pytest.mark.django_db
+def test_subordinate_update_rejects_protected_claim_without_changes(auth_client):
+    """Leave an existing subordinate unchanged when an update collides with `sub`."""
+    from entities.models import Subordinate
+
+    subordinate = Subordinate.objects.order_by("id").first()
+    assert subordinate is not None
+    original = (subordinate.additional_claims, subordinate.statement)
+
+    response = auth_client.post(
+        f"/api/v1/subordinates/{subordinate.id}",
+        data=json.dumps(
+            {
+                "metadata": {},
+                "forced_metadata": {},
+                "jwks": {},
+                "additional_claims": {"sub": "https://attacker.example"},
+            }
+        ),
+        content_type="application/json",
+    )
+
+    subordinate.refresh_from_db()
+    assert response.status_code == 422
+    assert (subordinate.additional_claims, subordinate.statement) == original
 
 
 @pytest.mark.django_db

--- a/admin/tests/test_claims.py
+++ b/admin/tests/test_claims.py
@@ -1,12 +1,17 @@
+import json
 from datetime import datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
+from django.contrib import admin
+from django.test import RequestFactory
 from jwcrypto import jwk, jwt
 from jwcrypto.common import json_decode
 
 from entities.lib import create_subordinate_statement
+from entities.models import Subordinate
 from trustmarks.lib import add_trustmark
+from trustmarks.models import TrustMark
 
 
 TRUST_MARK_PROTECTED_CLAIMS = ("iss", "sub", "iat", "exp", "trust_mark_type")
@@ -18,6 +23,11 @@ SUBORDINATE_PROTECTED_CLAIMS = (
     "jwks",
     "metadata",
     "metadata_policy",
+)
+
+ADMIN_PROTECTED_CLAIMS = (
+    *((TrustMark, claim) for claim in TRUST_MARK_PROTECTED_CLAIMS),
+    *((Subordinate, claim) for claim in SUBORDINATE_PROTECTED_CLAIMS),
 )
 
 
@@ -32,6 +42,78 @@ def public_keyset() -> jwk.JWKSet:
     keyset = jwk.JWKSet()
     keyset.add(jwk.JWK.generate(kty="EC", crv="P-256"))
     return keyset
+
+
+def get_admin_claims_form(model):
+    """Return the registered admin form limited to the field under test."""
+    request = RequestFactory().get("/admin/")
+    return admin.site._registry[model].get_form(request, fields=("additional_claims",))
+
+
+@pytest.mark.parametrize(("model", "protected_claim"), ADMIN_PROTECTED_CLAIMS)
+def test_admin_form_rejects_protected_additional_claim(model, protected_claim):
+    """Reject every protected claim through each registered Django admin form."""
+    form_type = get_admin_claims_form(model)
+    form = form_type(
+        data={"additional_claims": json.dumps({protected_claim: "attacker-controlled"})}
+    )
+
+    assert not form.is_valid()
+    assert protected_claim in form.errors["additional_claims"][0]
+
+
+@pytest.mark.parametrize(
+    ("model", "additional_claims"),
+    (
+        (TrustMark, {"ref": "https://example.com/reference", "nested": {"exp": 1}}),
+        (Subordinate, {"constraints": {"max_path_length": 1}, "nested": {"iss": "value"}}),
+    ),
+)
+def test_admin_form_allows_extension_claims(model, additional_claims):
+    """Preserve arbitrary and nested extension claims submitted through Django admin."""
+    form_type = get_admin_claims_form(model)
+    form = form_type(data={"additional_claims": json.dumps(additional_claims)})
+
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["additional_claims"] == additional_claims
+
+
+@pytest.mark.parametrize("model", (TrustMark, Subordinate))
+@pytest.mark.parametrize("value", ("[]", '"scalar"', "1", "true"))
+def test_admin_form_rejects_non_object_additional_claims(model, value):
+    """Return a field error instead of crashing on non-object JSON values."""
+    form_type = get_admin_claims_form(model)
+    form = form_type(data={"additional_claims": value})
+
+    assert not form.is_valid()
+    assert "additional_claims" in form.errors
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("model", "url_template", "protected_claim"),
+    (
+        (TrustMark, "/admin/trustmarks/trustmark/{id}/change/", "iss"),
+        (Subordinate, "/admin/entities/subordinate/{id}/change/", "sub"),
+    ),
+)
+def test_admin_change_rejects_protected_claim_without_persisting(
+    auth_client, model, url_template, protected_claim
+):
+    """Reject protected claims through the admin change view without modifying the row."""
+    instance = model.objects.order_by("id").first()
+    assert instance is not None
+    original_claims = instance.additional_claims
+
+    response = auth_client.post(
+        url_template.format(id=instance.id),
+        data={"additional_claims": json.dumps({protected_claim: "attacker-controlled"})},
+    )
+
+    instance.refresh_from_db()
+    assert response.status_code == 200
+    assert b"additional_claims contains protected claims" in response.content
+    assert instance.additional_claims == original_claims
 
 
 @pytest.mark.parametrize("protected_claim", TRUST_MARK_PROTECTED_CLAIMS)

--- a/admin/tests/test_claims.py
+++ b/admin/tests/test_claims.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+from jwcrypto import jwk, jwt
+from jwcrypto.common import json_decode
+
+from entities.lib import create_subordinate_statement
+from trustmarks.lib import add_trustmark
+
+
+TRUST_MARK_PROTECTED_CLAIMS = ("iss", "sub", "iat", "exp", "trust_mark_type")
+SUBORDINATE_PROTECTED_CLAIMS = (
+    "iss",
+    "sub",
+    "iat",
+    "exp",
+    "jwks",
+    "metadata",
+    "metadata_policy",
+)
+
+
+def get_payload(token: str) -> dict:
+    """Decode a JWT payload without verifying it."""
+    parsed = jwt.JWT.from_jose_token(token)
+    return json_decode(parsed.token.objects["payload"])
+
+
+def public_keyset() -> jwk.JWKSet:
+    """Create a public key set suitable for a subordinate statement."""
+    keyset = jwk.JWKSet()
+    keyset.add(jwk.JWK.generate(kty="EC", crv="P-256"))
+    return keyset
+
+
+@pytest.mark.parametrize("protected_claim", TRUST_MARK_PROTECTED_CLAIMS)
+def test_trust_mark_signing_rejects_protected_additional_claim(protected_claim):
+    """Reject Trust Mark claim collisions before signing or writing to Redis."""
+    redis = Mock()
+
+    with pytest.raises(ValueError, match=protected_claim):
+        add_trustmark(
+            "https://subject.example",
+            "https://issuer.example/trust-mark-type",
+            24,
+            {protected_claim: "attacker-controlled"},
+            redis,
+        )
+
+    redis.hset.assert_not_called()
+    redis.sadd.assert_not_called()
+
+
+@pytest.mark.parametrize("protected_claim", SUBORDINATE_PROTECTED_CLAIMS)
+def test_subordinate_signing_rejects_protected_additional_claim(protected_claim):
+    """Reject subordinate claim collisions at the signing boundary."""
+    now = datetime.now()
+
+    with pytest.raises(ValueError, match=protected_claim):
+        create_subordinate_statement(
+            "https://subject.example",
+            public_keyset(),
+            now,
+            now + timedelta(hours=24),
+            {"openid_relying_party": {}},
+            {protected_claim: "attacker-controlled"},
+        )
+
+
+def test_subordinate_signing_preserves_extension_claims(settings):
+    """Keep legitimate top-level and nested extension claims in the signed statement."""
+    now = datetime.now()
+    extensions = {
+        "constraints": {"max_path_length": 1},
+        "organization": {"iss": "nested-values-do-not-collide", "exp": 1},
+    }
+
+    token = create_subordinate_statement(
+        "https://subject.example",
+        public_keyset(),
+        now,
+        now + timedelta(hours=24),
+        {"openid_relying_party": {}},
+        extensions,
+    )
+    payload = get_payload(token)
+
+    assert payload["constraints"] == extensions["constraints"]
+    assert payload["organization"] == extensions["organization"]
+    assert payload["iss"] == settings.TA_DOMAIN
+    assert payload["sub"] == "https://subject.example"
+    assert payload["metadata"] == {"openid_relying_party": {}}

--- a/admin/trustmarks/admin.py
+++ b/admin/trustmarks/admin.py
@@ -1,6 +1,34 @@
+from typing import Any
+
+from django import forms
 from django.contrib import admin
+from django.core.exceptions import ValidationError
+
+from common.claims import validate_trust_mark_additional_claims
 
 from .models import TrustMark, TrustMarkType
 
+
+class TrustMarkAdminForm(forms.ModelForm):
+    """Validate Trust Mark extension claims submitted through Django admin."""
+
+    class Meta:
+        model = TrustMark
+        fields = "__all__"
+
+    def clean_additional_claims(self) -> dict[str, Any] | None:
+        """Reject claims controlled by the Trust Mark issuer."""
+        try:
+            return validate_trust_mark_additional_claims(self.cleaned_data.get("additional_claims"))
+        except ValueError as error:
+            raise ValidationError(str(error)) from error
+
+
+class TrustMarkAdmin(admin.ModelAdmin):
+    """Admin configuration for Trust Marks."""
+
+    form = TrustMarkAdminForm
+
+
 admin.site.register(TrustMarkType)
-admin.site.register(TrustMark)
+admin.site.register(TrustMark, TrustMarkAdmin)

--- a/admin/trustmarks/lib.py
+++ b/admin/trustmarks/lib.py
@@ -8,6 +8,7 @@ from jwcrypto import jwt
 from jwcrypto.common import json_decode
 from pydantic import BaseModel
 
+from common.claims import validate_trust_mark_additional_claims
 from common.signing import create_signed_jwt
 
 
@@ -38,15 +39,16 @@ def add_trustmark(
     """
     # Based on https://openid.net/specs/openid-federation-1_0.html#name-trust-marks
 
-    # This is the data we care for now
-    sub_data = {"iss": settings.TRUSTMARK_PROVIDER}
+    additional_claims = validate_trust_mark_additional_claims(additional_claims)
+
+    # Merge extensions first, then set claims that are authoritative for this issuer.
+    sub_data = dict(additional_claims or {})
+    sub_data["iss"] = settings.TRUSTMARK_PROVIDER
     sub_data["sub"] = entity
     now = datetime.now()
     exp = now + timedelta(hours=expiry)
     sub_data["iat"] = now.timestamp()
     sub_data["exp"] = exp.timestamp()
-    if additional_claims:
-        sub_data.update(additional_claims)
     sub_data["trust_mark_type"] = trustmarktype
 
     key = settings.SIGNING_PRIVATE_KEY

--- a/docs/api/admin.rst
+++ b/docs/api/admin.rst
@@ -341,7 +341,8 @@ Issues a new trust mark to an entity.
    * - ``additional_claims``
      - object
      - No
-     - Extra claims to include in the JWT
+     - Extra claims to include in the JWT; cannot contain ``iss``, ``sub``, ``iat``, ``exp``, or
+       ``trust_mark_type``
 
 **Response (201 Created):**
 
@@ -488,7 +489,8 @@ Update Trust Mark
    * - ``additional_claims``
      - object
      - No
-     - Extra claims to include in the JWT (triggers re-signing)
+     - Extra claims to include in the JWT (triggers re-signing); issuer-controlled claims are
+       rejected
 
 Setting ``active`` to ``false`` revokes the trust mark. The entity will
 no longer appear in trust mark lists, and status checks will return "revoked".
@@ -592,7 +594,8 @@ Registers a new subordinate entity.
    * - ``additional_claims``
      - object
      - No
-     - Extra claims for the subordinate statement
+     - Extra claims for the subordinate statement; cannot contain ``iss``, ``sub``, ``iat``,
+       ``exp``, ``jwks``, ``metadata``, or ``metadata_policy``
 
 **Validation:**
 
@@ -748,7 +751,7 @@ the entity configuration before creating a new signed statement.
    * - ``additional_claims``
      - object
      - No
-     - Extra claims for the subordinate statement
+     - Extra claims for the subordinate statement; issuer-controlled claims are rejected
 
 Renew Subordinate
 ^^^^^^^^^^^^^^^^^^

--- a/docs/guides/subordinates.rst
+++ b/docs/guides/subordinates.rst
@@ -213,6 +213,10 @@ Add custom claims to the subordinate statement:
        }
      }'
 
+The issuer-controlled claims ``iss``, ``sub``, ``iat``, ``exp``, ``jwks``, ``metadata``, and
+``metadata_policy`` are not allowed in ``additional_claims``. Use ``forced_metadata`` for
+TA-controlled metadata.
+
 Custom Validity Period
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/guides/trustmarks.rst
+++ b/docs/guides/trustmarks.rst
@@ -136,7 +136,9 @@ Add custom claims to the trust mark JWT:
        }
      }'
 
-The ``additional_claims`` appear directly in the trust mark JWT payload:
+The ``additional_claims`` appear directly in the trust mark JWT payload. The issuer-controlled
+claims ``iss``, ``sub``, ``iat``, ``exp``, and ``trust_mark_type`` are not allowed in
+``additional_claims``:
 
 .. code-block:: json
 

--- a/justfile
+++ b/justfile
@@ -34,10 +34,9 @@ lint-python: venv
   # The Python code is not packaged, so imports are currently
   # relative to the admin/ directory.
   # We don't check api_demo directory.
-  . .venv/bin/activate && \
-  ty check .  --exclude api_demo && \
-  ruff format --check && \
-  ruff check .
+  uv run ty check . --exclude api_demo
+  uv run ruff format --check
+  uv run ruff check .
 
 # To check for TypeScript errors in frontend
 [working-directory: 'admin/frontend']


### PR DESCRIPTION
Reject issuer-controlled claims before persistence and signing. Preserve valid extension claims and document the restrictions. Add regression tests for create, update, and signing paths.