### PR TITLE
fix: revoke API keys when users are disabled

### DIFF
--- a/admin/apikeys/admin.py
+++ b/admin/apikeys/admin.py
@@ -1,15 +1,35 @@
 """Django admin configuration for API Keys."""
 
+from django import forms
 from django.contrib import admin, messages
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.http import HttpRequest
 from django.utils.html import format_html
 
 from .models import APIKey
 
 
+class APIKeyAdminForm(forms.ModelForm):
+    """Validate API key ownership against current account state."""
+
+    class Meta:
+        model = APIKey
+        fields = "__all__"
+
+    def clean_user(self) -> User:
+        """Lock and reject an owner whose account is currently inactive."""
+        user = self.cleaned_data["user"]
+        current_user = User.objects.select_for_update().get(pk=user.pk)
+        if not current_user.is_active:
+            raise ValidationError("Cannot create an API key for an inactive user.")
+        return current_user
+
+
 class APIKeyAdmin(admin.ModelAdmin):
     """Admin interface for API Key management."""
 
+    form = APIKeyAdminForm
     list_display = [
         "name",
         "prefix_display",
@@ -75,9 +95,9 @@ class APIKeyAdmin(admin.ModelAdmin):
         )
 
     def get_readonly_fields(self, request: HttpRequest, obj=None):
-        """Make more fields readonly when editing existing key."""
+        """Prevent owner changes and reactivation of existing API keys."""
         if obj:  # Editing existing object
-            return self.readonly_fields + ["user"]
+            return self.readonly_fields + ["user", "is_active"]
         return self.readonly_fields
 
     def has_change_permission(self, request: HttpRequest, obj=None) -> bool:

--- a/admin/apikeys/management/commands/apikey.py
+++ b/admin/apikeys/management/commands/apikey.py
@@ -8,6 +8,7 @@ Usage:
 """
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand, CommandError
 
 from apikeys.models import APIKey
@@ -75,7 +76,10 @@ class Command(BaseCommand):
         except User.DoesNotExist:
             raise CommandError(f"User '{username}' does not exist")
 
-        _, plaintext_key = APIKey.create_key(name=key_name, user=user, tenant=tenant)
+        try:
+            _, plaintext_key = APIKey.create_key(name=key_name, user=user, tenant=tenant)
+        except ValidationError as error:
+            raise CommandError("; ".join(error.messages)) from error
 
         # Print only the key so it can be captured by scripts
         self.stdout.write(plaintext_key)

--- a/admin/apikeys/management/commands/create_api_key.py
+++ b/admin/apikeys/management/commands/create_api_key.py
@@ -6,6 +6,7 @@ Usage:
 """
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand, CommandError
 
 from apikeys.models import APIKey
@@ -38,7 +39,10 @@ class Command(BaseCommand):
         except User.DoesNotExist:
             raise CommandError(f"User '{username}' does not exist")
 
-        _, plaintext_key = APIKey.create_key(name=key_name, user=user)
+        try:
+            _, plaintext_key = APIKey.create_key(name=key_name, user=user)
+        except ValidationError as error:
+            raise CommandError("; ".join(error.messages)) from error
 
         # Print only the key so it can be captured by scripts
         self.stdout.write(plaintext_key)

--- a/admin/apikeys/migrations/0003_revoke_keys_on_user_status_change.py
+++ b/admin/apikeys/migrations/0003_revoke_keys_on_user_status_change.py
@@ -1,0 +1,51 @@
+"""Permanently revoke API keys whenever an owning user's status changes."""
+
+from django.db import migrations
+
+
+CREATE_REVOCATION_TRIGGER = """
+CREATE FUNCTION apikeys_revoke_on_user_status_change()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE apikeys_apikey
+    SET is_active = FALSE
+    WHERE user_id = NEW.id AND is_active = TRUE;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER apikeys_revoke_on_user_status_change
+AFTER UPDATE OF is_active ON auth_user
+FOR EACH ROW
+WHEN (OLD.is_active IS DISTINCT FROM NEW.is_active)
+EXECUTE FUNCTION apikeys_revoke_on_user_status_change();
+
+-- Permanently revoke keys for accounts that were inactive before this migration.
+UPDATE apikeys_apikey AS api_key
+SET is_active = FALSE
+FROM auth_user AS owner
+WHERE api_key.user_id = owner.id
+  AND api_key.is_active = TRUE
+  AND owner.is_active = FALSE;
+"""
+
+
+DROP_REVOCATION_TRIGGER = """
+DROP TRIGGER IF EXISTS apikeys_revoke_on_user_status_change ON auth_user;
+DROP FUNCTION IF EXISTS apikeys_revoke_on_user_status_change();
+"""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("apikeys", "0002_add_tenant_field"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=CREATE_REVOCATION_TRIGGER,
+            reverse_sql=DROP_REVOCATION_TRIGGER,
+        ),
+    ]

--- a/admin/apikeys/migrations/0003_revoke_keys_on_user_status_change.py
+++ b/admin/apikeys/migrations/0003_revoke_keys_on_user_status_change.py
@@ -4,6 +4,49 @@ from django.db import migrations
 
 
 CREATE_REVOCATION_TRIGGER = """
+CREATE FUNCTION apikeys_require_active_owner()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM 1
+    FROM auth_user
+    WHERE id = NEW.user_id AND is_active = TRUE
+    FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'API keys require an active user'
+            USING ERRCODE = '23514';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER apikeys_require_active_owner_on_insert
+BEFORE INSERT ON apikeys_apikey
+FOR EACH ROW
+EXECUTE FUNCTION apikeys_require_active_owner();
+
+CREATE TRIGGER apikeys_require_active_owner_on_reassignment
+BEFORE UPDATE OF user_id ON apikeys_apikey
+FOR EACH ROW
+EXECUTE FUNCTION apikeys_require_active_owner();
+
+CREATE FUNCTION apikeys_prevent_key_reactivation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'Revoked API keys cannot be reactivated'
+        USING ERRCODE = '23514';
+END;
+$$;
+
+CREATE TRIGGER apikeys_prevent_key_reactivation
+BEFORE UPDATE OF is_active ON apikeys_apikey
+FOR EACH ROW
+WHEN (OLD.is_active = FALSE AND NEW.is_active = TRUE)
+EXECUTE FUNCTION apikeys_prevent_key_reactivation();
+
 CREATE FUNCTION apikeys_revoke_on_user_status_change()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -33,6 +76,11 @@ WHERE api_key.user_id = owner.id
 
 
 DROP_REVOCATION_TRIGGER = """
+DROP TRIGGER IF EXISTS apikeys_require_active_owner_on_insert ON apikeys_apikey;
+DROP TRIGGER IF EXISTS apikeys_require_active_owner_on_reassignment ON apikeys_apikey;
+DROP FUNCTION IF EXISTS apikeys_require_active_owner();
+DROP TRIGGER IF EXISTS apikeys_prevent_key_reactivation ON apikeys_apikey;
+DROP FUNCTION IF EXISTS apikeys_prevent_key_reactivation();
 DROP TRIGGER IF EXISTS apikeys_revoke_on_user_status_change ON auth_user;
 DROP FUNCTION IF EXISTS apikeys_revoke_on_user_status_change();
 """

--- a/admin/apikeys/models.py
+++ b/admin/apikeys/models.py
@@ -4,7 +4,8 @@ import hashlib
 import secrets
 
 from django.contrib.auth.models import User
-from django.db import models
+from django.core.exceptions import ValidationError
+from django.db import models, transaction
 from django.utils import timezone
 
 
@@ -112,17 +113,24 @@ class APIKey(models.Model):
         Returns:
             tuple: (APIKey instance, plaintext key)
             Note: The plaintext key is only available at creation time!
+
+        Raises:
+            ValidationError: If the owning user is currently inactive.
         """
-        full_key, prefix, key_hash = generate_api_key()
-        api_key = cls.objects.create(
-            name=name,
-            prefix=prefix,
-            key_hash=key_hash,
-            user=user,
-            expires_at=expires_at,
-            is_active=user.is_active,
-            tenant=tenant,
-        )
+        with transaction.atomic():
+            current_user = User.objects.select_for_update().get(pk=user.pk)
+            if not current_user.is_active:
+                raise ValidationError("Cannot create an API key for an inactive user.")
+
+            full_key, prefix, key_hash = generate_api_key()
+            api_key = cls.objects.create(
+                name=name,
+                prefix=prefix,
+                key_hash=key_hash,
+                user=current_user,
+                expires_at=expires_at,
+                tenant=tenant,
+            )
         return api_key, full_key
 
     @classmethod

--- a/admin/apikeys/models.py
+++ b/admin/apikeys/models.py
@@ -85,8 +85,8 @@ class APIKey(models.Model):
 
     @property
     def is_valid(self) -> bool:
-        """Check if the API key is currently valid."""
-        if not self.is_active:
+        """Check whether the key and its owning account are active and unexpired."""
+        if not self.is_active or not self.user.is_active:
             return False
         if self.expires_at and timezone.now() > self.expires_at:
             return False
@@ -120,6 +120,7 @@ class APIKey(models.Model):
             key_hash=key_hash,
             user=user,
             expires_at=expires_at,
+            is_active=user.is_active,
             tenant=tenant,
         )
         return api_key, full_key

--- a/admin/tests/test_apikeys.py
+++ b/admin/tests/test_apikeys.py
@@ -5,7 +5,9 @@ from datetime import timedelta
 
 import pytest
 from django.contrib.auth.models import User
-from django.test import Client
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, transaction
+from django.test import Client, RequestFactory
 from django.utils import timezone
 
 from apikeys.models import APIKey, generate_api_key, hash_api_key
@@ -86,15 +88,15 @@ class TestAPIKeyModel:
 
     @pytest.mark.django_db
     def test_key_owned_by_inactive_user_is_invalid(self, user):
-        """Test the runtime check blocks an active key in inconsistent storage."""
-        api_key, _ = APIKey.create_key(
+        """Test the runtime validity check includes the owning account state."""
+        user.is_active = False
+        api_key = APIKey(
             name="Inactive User Key",
+            prefix="inactive",
+            key_hash="unused",
             user=user,
         )
-        User.objects.filter(pk=user.pk).update(is_active=False)
-        APIKey.objects.filter(pk=api_key.pk).update(is_active=True)
 
-        api_key = APIKey.objects.select_related("user").get(pk=api_key.pk)
         assert api_key.is_active is True
         assert api_key.is_valid is False
 
@@ -111,23 +113,34 @@ class TestAPIKeyModel:
         assert APIKey.authenticate(plaintext) is None
 
     @pytest.mark.django_db
-    def test_bulk_reactivation_revokes_key_inserted_for_inactive_user(self, user):
-        """Test reactivation revokes an active key inserted while its owner was inactive."""
-        plaintext, prefix, key_hash = generate_api_key()
+    def test_direct_insert_rejects_inactive_owner(self, user):
+        """Test direct ORM inserts cannot create a key for an inactive owner."""
+        _, prefix, key_hash = generate_api_key()
         User.objects.filter(pk=user.pk).update(is_active=False)
-        api_key = APIKey.objects.create(
-            name="Inconsistent Dormant Key",
-            prefix=prefix,
-            key_hash=key_hash,
-            user=user,
-        )
-        assert api_key.is_active is True
 
-        User.objects.filter(pk=user.pk).update(is_active=True)
+        with pytest.raises(IntegrityError, match="require an active user"):
+            with transaction.atomic():
+                APIKey.objects.create(
+                    name="Rejected Inactive Owner Key",
+                    prefix=prefix,
+                    key_hash=key_hash,
+                    user=user,
+                )
+
+        assert not APIKey.objects.filter(name="Rejected Inactive Owner Key").exists()
+
+    @pytest.mark.django_db
+    def test_bulk_reassignment_rejects_inactive_owner(self, user):
+        """Test bulk updates cannot reassign an API key to an inactive owner."""
+        api_key, _ = APIKey.create_key(name="Owner Reassignment Key", user=user)
+        inactive_user = User.objects.create_user(username="inactive-reassignment", is_active=False)
+
+        with pytest.raises(IntegrityError, match="require an active user"):
+            with transaction.atomic():
+                APIKey.objects.filter(pk=api_key.pk).update(user=inactive_user)
 
         api_key.refresh_from_db()
-        assert api_key.is_active is False
-        assert APIKey.authenticate(plaintext) is None
+        assert api_key.user == user
 
     @pytest.mark.django_db
     def test_deactivating_user_revokes_all_owned_keys(self, user):
@@ -161,13 +174,44 @@ class TestAPIKeyModel:
         assert APIKey.authenticate(plaintext) is None
 
     @pytest.mark.django_db
-    def test_key_created_for_inactive_user_is_inactive(self, user):
-        """Test newly created keys cannot outlive an already-inactive account."""
-        user.is_active = False
-        user.save(update_fields=["is_active"])
+    def test_key_creation_rejects_inactive_user(self, user):
+        """Test key creation rejects a stale instance of an inactive owner."""
+        stale_user = User.objects.get(pk=user.pk)
+        User.objects.filter(pk=user.pk).update(is_active=False)
+        assert stale_user.is_active is True
 
-        api_key, plaintext = APIKey.create_key(name="Dormant Key", user=user)
+        with pytest.raises(ValidationError, match="inactive user"):
+            APIKey.create_key(name="Dormant Key", user=stale_user)
 
+        assert not APIKey.objects.filter(name="Dormant Key").exists()
+
+    @pytest.mark.django_db
+    def test_revoked_key_cannot_be_reactivated_with_save(self, user):
+        """Test saving a revoked key as active is rejected permanently."""
+        api_key, plaintext = APIKey.create_key(name="Save Revocation Key", user=user)
+        api_key.is_active = False
+        api_key.save(update_fields=["is_active"])
+
+        api_key.is_active = True
+        with pytest.raises(IntegrityError, match="cannot be reactivated"):
+            with transaction.atomic():
+                api_key.save(update_fields=["is_active"])
+
+        api_key.refresh_from_db()
+        assert api_key.is_active is False
+        assert APIKey.authenticate(plaintext) is None
+
+    @pytest.mark.django_db
+    def test_revoked_key_cannot_be_reactivated_with_bulk_update(self, user):
+        """Test bulk updates cannot reactivate a revoked API key."""
+        api_key, plaintext = APIKey.create_key(name="Bulk Revocation Key", user=user)
+        APIKey.objects.filter(pk=api_key.pk).update(is_active=False)
+
+        with pytest.raises(IntegrityError, match="cannot be reactivated"):
+            with transaction.atomic():
+                APIKey.objects.filter(pk=api_key.pk).update(is_active=True)
+
+        api_key.refresh_from_db()
         assert api_key.is_active is False
         assert APIKey.authenticate(plaintext) is None
 
@@ -356,6 +400,45 @@ class TestAPIKeyAuthentication:
         assert response.status_code == 200
 
 
+class TestAPIKeyAdmin:
+    """Tests for irreversible revocation in the Django admin."""
+
+    @pytest.mark.django_db
+    def test_existing_key_active_state_is_readonly(self, user):
+        """Test the admin cannot expose a control that restores an existing key."""
+        from django.contrib import admin
+
+        from apikeys.admin import APIKeyAdmin
+
+        api_key, _ = APIKey.create_key(name="Admin Readonly Key", user=user)
+        model_admin = APIKeyAdmin(APIKey, admin.site)
+        request = RequestFactory().get("/admin/apikeys/apikey/")
+
+        readonly_fields = model_admin.get_readonly_fields(request=request, obj=api_key)
+
+        assert "is_active" in readonly_fields
+
+    @pytest.mark.django_db
+    def test_admin_rejects_key_for_inactive_user(self, auth_client):
+        """Test the admin add form rejects an inactive key owner."""
+        inactive_user = User.objects.create_user(username="inactive-key-owner", is_active=False)
+
+        response = auth_client.post(
+            "/admin/apikeys/apikey/add/",
+            data={
+                "name": "Rejected Admin Key",
+                "user": inactive_user.pk,
+                "tenant": "default",
+                "is_active": "on",
+                "_save": "Save",
+            },
+        )
+
+        assert response.status_code == 200
+        assert b"Cannot create an API key for an inactive user." in response.content
+        assert not APIKey.objects.filter(name="Rejected Admin Key").exists()
+
+
 class TestAPIKeyManagementCommand:
     """Tests for the apikey management command."""
 
@@ -412,6 +495,29 @@ class TestAPIKeyManagementCommand:
 
         with pytest.raises(CommandError, match="does not exist"):
             call_command("apikey", "create", "--username", "nobody", stdout=StringIO())
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        ("command", "arguments"),
+        [
+            ("apikey", ["create", "--username", "testuser"]),
+            ("create_api_key", ["--username", "testuser"]),
+        ],
+    )
+    def test_create_commands_reject_inactive_user(self, user, command, arguments):
+        """Test both creation commands reject inactive key owners without output."""
+        from io import StringIO
+
+        from django.core.management import call_command, CommandError
+
+        user.is_active = False
+        user.save(update_fields=["is_active"])
+        out = StringIO()
+
+        with pytest.raises(CommandError, match="inactive user"):
+            call_command(command, *arguments, stdout=out)
+
+        assert out.getvalue() == ""
 
     @pytest.mark.django_db
     def test_apikey_list(self, user):

--- a/admin/tests/test_apikeys.py
+++ b/admin/tests/test_apikeys.py
@@ -4,6 +4,7 @@ import json
 from datetime import timedelta
 
 import pytest
+from django.contrib.auth.models import User
 from django.test import Client
 from django.utils import timezone
 
@@ -84,6 +85,93 @@ class TestAPIKeyModel:
         assert api_key.is_valid is False
 
     @pytest.mark.django_db
+    def test_key_owned_by_inactive_user_is_invalid(self, user):
+        """Test the runtime check blocks an active key in inconsistent storage."""
+        api_key, _ = APIKey.create_key(
+            name="Inactive User Key",
+            user=user,
+        )
+        User.objects.filter(pk=user.pk).update(is_active=False)
+        APIKey.objects.filter(pk=api_key.pk).update(is_active=True)
+
+        api_key = APIKey.objects.select_related("user").get(pk=api_key.pk)
+        assert api_key.is_active is True
+        assert api_key.is_valid is False
+
+    @pytest.mark.django_db
+    def test_bulk_user_status_changes_cannot_restore_keys(self, user):
+        """Test bulk deactivation and reactivation cannot restore an API key."""
+        api_key, plaintext = APIKey.create_key(name="Bulk Revoked Key", user=user)
+
+        User.objects.filter(pk=user.pk).update(is_active=False)
+        api_key.refresh_from_db()
+        assert api_key.is_active is False
+
+        User.objects.filter(pk=user.pk).update(is_active=True)
+        assert APIKey.authenticate(plaintext) is None
+
+    @pytest.mark.django_db
+    def test_bulk_reactivation_revokes_key_inserted_for_inactive_user(self, user):
+        """Test reactivation revokes an active key inserted while its owner was inactive."""
+        plaintext, prefix, key_hash = generate_api_key()
+        User.objects.filter(pk=user.pk).update(is_active=False)
+        api_key = APIKey.objects.create(
+            name="Inconsistent Dormant Key",
+            prefix=prefix,
+            key_hash=key_hash,
+            user=user,
+        )
+        assert api_key.is_active is True
+
+        User.objects.filter(pk=user.pk).update(is_active=True)
+
+        api_key.refresh_from_db()
+        assert api_key.is_active is False
+        assert APIKey.authenticate(plaintext) is None
+
+    @pytest.mark.django_db
+    def test_deactivating_user_revokes_all_owned_keys(self, user):
+        """Test deactivating a user permanently revokes all of their API keys."""
+        first_key, _ = APIKey.create_key(name="First Key", user=user)
+        second_key, _ = APIKey.create_key(name="Second Key", user=user)
+        other_user = User.objects.create_user(username="other-key-owner")
+        other_key, _ = APIKey.create_key(name="Other User Key", user=other_user)
+
+        user.is_active = False
+        user.save()
+
+        first_key.refresh_from_db()
+        second_key.refresh_from_db()
+        other_key.refresh_from_db()
+        assert first_key.is_active is False
+        assert second_key.is_active is False
+        assert other_key.is_active is True
+
+    @pytest.mark.django_db
+    def test_reactivating_user_does_not_reactivate_keys(self, user):
+        """Test reactivating an account does not restore its revoked API keys."""
+        api_key, plaintext = APIKey.create_key(name="Revoked User Key", user=user)
+        user.is_active = False
+        user.save(update_fields=["is_active"])
+        user.is_active = True
+        user.save(update_fields=["is_active"])
+
+        api_key.refresh_from_db()
+        assert api_key.is_active is False
+        assert APIKey.authenticate(plaintext) is None
+
+    @pytest.mark.django_db
+    def test_key_created_for_inactive_user_is_inactive(self, user):
+        """Test newly created keys cannot outlive an already-inactive account."""
+        user.is_active = False
+        user.save(update_fields=["is_active"])
+
+        api_key, plaintext = APIKey.create_key(name="Dormant Key", user=user)
+
+        assert api_key.is_active is False
+        assert APIKey.authenticate(plaintext) is None
+
+    @pytest.mark.django_db
     def test_authenticate_valid_key(self, user):
         """Test authentication with a valid API key."""
         api_key, plaintext = APIKey.create_key(
@@ -128,6 +216,21 @@ class TestAPIKeyModel:
 
         result = APIKey.authenticate(plaintext)
         assert result is None
+
+    @pytest.mark.django_db
+    def test_authenticate_inactive_users_key(self, user):
+        """Test authentication rejects a key when its owner is inactive."""
+        api_key, plaintext = APIKey.create_key(
+            name="Inactive User Auth Key",
+            user=user,
+        )
+        User.objects.filter(pk=user.pk).update(is_active=False)
+
+        result = APIKey.authenticate(plaintext)
+
+        assert result is None
+        api_key.refresh_from_db()
+        assert api_key.last_used_at is None
 
     @pytest.mark.django_db
     def test_last_used_updated(self, user):
@@ -186,6 +289,27 @@ class TestAPIKeyAuthentication:
         )
 
         assert response.status_code == 200
+
+    @pytest.mark.django_db
+    def test_api_access_denied_when_key_owner_is_inactive(self, user):
+        """Test API access is denied when the key owner is inactive."""
+        api_key, plaintext = APIKey.create_key(
+            name="Inactive User API Key",
+            user=user,
+        )
+        user.is_active = False
+        user.save(update_fields=["is_active"])
+
+        api_key.refresh_from_db()
+        assert api_key.is_active is False
+
+        client = Client()
+        response = client.get(
+            "/api/v1/trustmarktypes",
+            HTTP_X_API_KEY=plaintext,
+        )
+
+        assert response.status_code == 401
 
     @pytest.mark.django_db
     def test_api_access_with_invalid_key(self, db):
@@ -313,7 +437,6 @@ class TestAPIKeyManagementCommand:
         """Test listing all API keys across users."""
         from io import StringIO
 
-        from django.contrib.auth.models import User
         from django.core.management import call_command
 
         user2 = User.objects.create_user(username="otheruser", password="pass123")

--- a/docs/guides/api-keys.rst
+++ b/docs/guides/api-keys.rst
@@ -22,6 +22,7 @@ for:
 Each API key is:
 
 * Tied to a specific Django user account
+* Usable only while both the key and its user account are active
 * Stored as a SHA-256 hash (the plaintext is shown only once at creation)
 * Optionally time-limited with an expiry date
 * Revocable at any time
@@ -170,6 +171,9 @@ Security Best Practices
 * **Set expiry dates** -- avoid permanent keys when possible
 * **Use descriptive names** -- makes it easy to identify and audit keys
 * **Revoke unused keys** -- regularly review and clean up old keys
+* **Disable departed users** -- disabling an account immediately and
+  permanently deactivates all API keys owned by that account. Re-enabling the
+  account does not reactivate those keys; create new keys instead
 * **One key per client** -- don't share keys between different services
 * **Store keys securely** -- treat them like passwords; use environment
   variables or a secrets manager
@@ -182,9 +186,13 @@ The authentication flow:
 1. Client sends request with ``X-API-Key: <key>`` header
 2. ``APIKeyAuthBackend`` (in ``inmoradmin/auth.py``) extracts the header
 3. The key is hashed with SHA-256 and looked up in the database
-4. If found, active, and not expired, the request is authenticated as the
-   key's associated user
+4. If the key and its associated user account are active, and the key is not
+   expired, the request is authenticated as that user
 5. The ``last_used_at`` timestamp is updated
+
+Disabling a user permanently deactivates all of that user's existing API keys.
+Keys created for an already-inactive user are also inactive. Re-enabling the
+user never reactivates these keys.
 
 The API router in ``inmoradmin/api.py`` uses ``combined_auth`` to support API
 keys for direct callers and sessions already established by django-allauth for

--- a/docs/guides/api-keys.rst
+++ b/docs/guides/api-keys.rst
@@ -23,6 +23,7 @@ Each API key is:
 
 * Tied to a specific Django user account
 * Usable only while both the key and its user account are active
+* Created only for active user accounts
 * Stored as a SHA-256 hash (the plaintext is shown only once at creation)
 * Optionally time-limited with an expiry date
 * Revocable at any time
@@ -153,9 +154,9 @@ Revoking Keys
 
 To revoke a single key:
 
-1. Click on the key in the admin list
-2. Uncheck **Is active**
-3. Click **Save**
+1. Select the key using its checkbox
+2. Choose **Revoke selected API keys** from the action dropdown
+3. Click **Go**
 
 To revoke multiple keys at once:
 
@@ -191,8 +192,8 @@ The authentication flow:
 5. The ``last_used_at`` timestamp is updated
 
 Disabling a user permanently deactivates all of that user's existing API keys.
-Keys created for an already-inactive user are also inactive. Re-enabling the
-user never reactivates these keys.
+New keys cannot be created for an inactive user. Re-enabling the user never
+reactivates old keys; create a new key instead.
 
 The API router in ``inmoradmin/api.py`` uses ``combined_auth`` to support API
 keys for direct callers and sessions already established by django-allauth for


### PR DESCRIPTION
Reject API key authentication for inactive users and permanently deactivate owned keys when account status changes. Cover bulk updates and existing inactive accounts with a database trigger, prevent key restoration after reactivation, and add lifecycle regression tests and documentation.